### PR TITLE
RIDER-18116: Open at top level when completing out of scope items

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Common/src/Checker/FSharpOptions.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/Checker/FSharpOptions.fs
@@ -11,7 +11,8 @@ open JetBrains.UI.RichText
 [<AutoOpen>]
 module FSharpOptions =
     let [<Literal>] backgroundTypeCheck = "Enable background type checking"  
-    let [<Literal>] outOfScopeCompletion = "Enable out of scope items completion"  
+    let [<Literal>] outOfScopeCompletion = "Enable out of scope items completion"
+    let [<Literal>] topLevelOpenCompletion = "Open namespaces at top-level when completing out of scope items"
 
 
 [<SettingsKey(typeof<HierarchySettings>, "FSharpOptions")>]
@@ -22,6 +23,9 @@ type FSharpOptions() =
     [<SettingsEntry(true, outOfScopeCompletion); DefaultValue>]
     val mutable EnableOutOfScopeCompletion: bool
 
+    [<SettingsEntry(true, topLevelOpenCompletion); DefaultValue>]
+    val mutable TopLevelOpenCompletion: bool
+
 
 [<OptionsPage("FSharpOptionsPage", "F#", typeof<ProjectModelThemedIcons.Fsharp>)>]
 type FSharpOptionsPage
@@ -31,3 +35,4 @@ type FSharpOptionsPage
     do
         this.AddBoolOption((fun (key: FSharpOptions) -> key.BackgroundTypeCheck), RichText(backgroundTypeCheck), null) |> ignore
         this.AddBoolOption((fun (key: FSharpOptions) -> key.EnableOutOfScopeCompletion), RichText(outOfScopeCompletion), null) |> ignore
+        this.AddBoolOption((fun (key: FSharpOptions) -> key.TopLevelOpenCompletion), RichText(topLevelOpenCompletion), null) |> ignore

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/CodeCompletion/FSharpLookupItem.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/CodeCompletion/FSharpLookupItem.fs
@@ -1,12 +1,14 @@
 namespace rec JetBrains.ReSharper.Plugins.FSharp.Psi.Features.CodeCompletion
 
 open System
+open JetBrains.Application.Settings
 open JetBrains.ReSharper.Feature.Services.CodeCompletion.Infrastructure.LookupItems
 open JetBrains.ReSharper.Feature.Services.CodeCompletion.Infrastructure.LookupItems.Impl
 open JetBrains.ReSharper.Feature.Services.Lookup
 open JetBrains.ReSharper.Feature.Services.ParameterInfo
 open JetBrains.ReSharper.Host.Features.Completion
 open JetBrains.ReSharper.Plugins.FSharp
+open JetBrains.ReSharper.Plugins.FSharp.Common.Checker.Settings
 open JetBrains.ReSharper.Plugins.FSharp.Common.Util
 open JetBrains.ReSharper.Plugins.FSharp.Psi.Features
 open JetBrains.ReSharper.Plugins.FSharp.Services.Cs.CodeCompletion
@@ -96,7 +98,12 @@ type FSharpLookupItem(item: FSharpDeclarationListItem, context: FSharpCodeComple
 
         let line = int context.Coords.Line + 1
         let parseTree = context.FSharpFile.ParseResults.Value.ParseTree.Value
-        let insertionPoint = OpenStatementInsertionPoint.Nearest
+        let insertionPoint =
+            let settings = context.BasicContext.ContextBoundSettingsStore
+            if settings.GetValue(fun (key: FSharpOptions) -> key.TopLevelOpenCompletion) then
+                OpenStatementInsertionPoint.TopLevel
+            else
+                OpenStatementInsertionPoint.Nearest
 
         let document = textControl.Document
         let context = ParsedInput.findNearestPointToInsertOpenDeclaration line parseTree [||] insertionPoint


### PR DESCRIPTION
Adds a setting to add 'open' at the top level of the file.  This also sets the default to match with Visual Studio's new default (https://github.com/Microsoft/visualfsharp/pull/5738)

In action:

![top level open](https://user-images.githubusercontent.com/64654/53522301-f97ff800-3ad1-11e9-9369-d056ff595cb4.gif)
