### PR TITLE
Implement Surround with braces behavior in typing assist

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/FSharpTypingAssist.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/FSharpTypingAssist.fs
@@ -128,14 +128,13 @@ type FSharpTypingAssist
     let leftToRightBracket =
         [| '(', ')'
            '[', ']'
-           '{', '}'  |]
+           '{', '}' |]
         |> dict
         
     let rightToLeftBracket =
         leftToRightBracket
         |> Seq.map(fun (KeyValue (key, value)) -> value, key)
-        |> dict
-        
+        |> dict        
         
     let bracketToTokenType =
         [| '(', FSharpTokenType.LPAREN
@@ -143,8 +142,7 @@ type FSharpTypingAssist
            '[', FSharpTokenType.LBRACK
            ']', FSharpTokenType.RBRACK
            '{', FSharpTokenType.LBRACE
-           '}', FSharpTokenType.RBRACE
-        |]
+           '}', FSharpTokenType.RBRACE |]
         |> dict
 
     let getIndentSize (textControl: ITextControl) =
@@ -948,14 +946,16 @@ type FSharpTypingAssist
     member x.HandleSurroundTyping(typingContext, lChar, rChar, lTokenType, rTokenType, shouldNotSurround) =
         base.HandleSurroundTyping(typingContext, lChar, rChar, lTokenType, rTokenType, shouldNotSurround)
         
-    member x.TrySurroundWithBraces(typingContext: ITypingContext , typedBracket, typedBracketIsLeft, matchingBrackets: IDictionary<_, _>) =
-        let mutable secondBrace = Unchecked.defaultof<_>
-        match matchingBrackets.TryGetValue(typedBracket, &secondBrace) with
-        | true ->
-            if not typedBracketIsLeft
-            then x.HandleSurroundTyping(typingContext, secondBrace, typedBracket, bracketToTokenType.[secondBrace], bracketToTokenType.[typedBracket], fun _ -> false)
-            else x.HandleSurroundTyping(typingContext, typedBracket, secondBrace, bracketToTokenType.[typedBracket], bracketToTokenType.[secondBrace], fun _ -> false)                                             
-        | _ -> true            
+    member x.TrySurroundWithBraces(typingContext, typedBracket, typedBracketIsLeft,
+                                   matchingBrackets: IDictionary<_, _>) =
+        let mutable secondBracket = Unchecked.defaultof<_>
+        match matchingBrackets.TryGetValue(typedBracket, &secondBracket) with
+        | false -> true
+        | _ ->
+
+        let lBrace, rBrace = if typedBracketIsLeft then typedBracket, secondBracket else secondBracket, typedBracket  
+        x.HandleSurroundTyping(typingContext, lBrace, rBrace, bracketToTokenType.[lBrace], bracketToTokenType.[rBrace],
+                               fun _ -> false)
     
     member x.HandleLeftBracket(context: ITypingContext) =
         this.HandleLeftBracketTyped

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 01.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 01.fs
@@ -1,0 +1,4 @@
+// ${CHAR:(}
+module Module
+
+let {selstart}foo{selend} = 1

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 01.fs.gold
@@ -1,0 +1,4 @@
+﻿// ${CHAR:(}
+module Module
+
+let ({caret}foo) = 1

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 02.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 02.fs
@@ -1,0 +1,4 @@
+// ${CHAR:)}
+module Module
+
+let {selstart}foo{selend} = 1

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 02.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 02.fs.gold
@@ -1,0 +1,4 @@
+﻿// ${CHAR:)}
+module Module
+
+let (foo{caret}) = 1

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 03.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 03.fs
@@ -1,0 +1,4 @@
+// ${CHAR:(}
+module Module
+
+let {selend}foo{selstart} = 1

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 03.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 03.fs.gold
@@ -1,0 +1,4 @@
+﻿// ${CHAR:(}
+module Module
+
+let ({caret}foo) = 1

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 04.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 04.fs
@@ -1,0 +1,4 @@
+// ${CHAR:)}
+module Module
+
+let {selend}foo{selstart} = 1

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 04.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 04.fs.gold
@@ -1,0 +1,4 @@
+﻿// ${CHAR:)}
+module Module
+
+let (foo{caret}) = 1

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 05.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 05.fs
@@ -1,0 +1,4 @@
+// ${CHAR:{}
+module Module
+
+{selend}let foo = 1{selstart}

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 05.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 05.fs.gold
@@ -1,0 +1,4 @@
+﻿// ${CHAR:{}
+module Module
+
+{{caret}let foo = 1}

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 06.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 06.fs
@@ -1,0 +1,4 @@
+// ${CHAR:]}
+module Module
+
+let foo = {selstart}1{selend}

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 06.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Brackets - Surround 06.fs.gold
@@ -1,0 +1,4 @@
+﻿// ${CHAR:]}
+module Module
+
+let foo = [1{caret}]

--- a/ReSharper.FSharp/test/src/FSharp.Tests/TypingAssistTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/TypingAssistTest.fs
@@ -238,6 +238,13 @@ type FSharpTypingAssistTest() =
     [<Test>] member x.``At 08 - Inside empty typed quotations and spaces 06``() = x.DoNamedTest()
     [<Test>] member x.``At 09 - Inside empty typed quotations and spaces 07``() = x.DoNamedTest()
     [<Test>] member x.``At 10 - Inside empty typed quotations and spaces 08``() = x.DoNamedTest()
+    
+    [<Test>] member x.``Brackets - Surround 01``() = x.DoNamedTest()
+    [<Test>] member x.``Brackets - Surround 02``() = x.DoNamedTest()
+    [<Test>] member x.``Brackets - Surround 03``() = x.DoNamedTest()
+    [<Test>] member x.``Brackets - Surround 04``() = x.DoNamedTest()
+    [<Test>] member x.``Brackets - Surround 05``() = x.DoNamedTest()
+    [<Test>] member x.``Brackets - Surround 06``() = x.DoNamedTest()
 
 [<FSharpTest>]
 type LineIndentsTest() =


### PR DESCRIPTION
Fixes RIDER-23963 "Surround Selection on typing brace or parenthesis" has no effect in F#