### PR TITLE
Add Azure Functions scope for templates

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Features/FSharp.Psi.Features.fsproj
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/FSharp.Psi.Features.fsproj
@@ -38,6 +38,7 @@
     <EmbeddedResource Include="src\FileTemplates\FileTemplates.xml">
       <LogicalName>JetBrains.ReSharper.Plugins.FSharp.Templates.FileTemplates.xml</LogicalName>
     </EmbeddedResource>
+    <Compile Include="src\FileTemplates\AzureFSharpScopeProvider.fs" />
     <Compile Include="src\Foldings\FSharpCodeFoldings.fs" />
     <Compile Include="src\Search\FSharpItemOccurrenceKind.fs" />
     <Compile Include="src\Search\FSharpPathReference.fs" />

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/FileTemplates/AzureFSharpScopeProvider.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/FileTemplates/AzureFSharpScopeProvider.fs
@@ -1,0 +1,50 @@
+namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Features.FileTemplates
+
+open System
+open JetBrains.Application
+open JetBrains.Application.UI.Options
+open JetBrains.ProjectModel.Resources
+open JetBrains.ReSharper.Feature.Services.LiveTemplates.Scope
+open JetBrains.ReSharper.Host.Features.LiveTemplates.Scope
+open JetBrains.ReSharper.LiveTemplates.UI
+open JetBrains.ReSharper.Plugins.FSharp
+open JetBrains.ReSharper.Plugins.FSharp.ProjectModel
+
+type InAzureFunctionsFSharpProject() =
+    inherit InAzureFunctionsProject()
+    static let ourDefaultGuid = Guid("6EAE234E-60AA-410E-B021-D219A2478F98")
+
+    override x.GetDefaultUID() = ourDefaultGuid
+    override x.PresentableShortName = "Azure Functions (F#) projects"
+
+[<ShellComponent>]
+type AzureFSharpScopeProvider() as this =
+    inherit AzureProjectScopeProvider()
+
+    do this.Creators.Add(fun x -> this.TryToCreateScope(x) :> _)
+
+    member this.TryToCreateScope(x) = base.TryToCreate<InAzureFunctionsFSharpProject>(x)
+
+    override x.GetLanguageSpecificScopePoints project =
+        let baseItems = base.GetLanguageSpecificScopePoints project
+        seq {
+            yield! baseItems
+            if project.ProjectProperties.DefaultLanguage = FSharpProjectLanguage.Instance then
+                yield InAzureFunctionsFSharpProject()
+        }
+
+[<ScopeCategoryUIProvider(Priority = -41., ScopeFilter = ScopeFilter.Project)>]
+type AzureFSharpProjectScopeCategoryUIProvider() as this =
+    inherit ScopeCategoryUIProvider(JetBrains.ProjectModel.Resources.ProjectModelThemedIcons.Fsharp.Id)
+    do
+        this.MainPoint <- InAzureFunctionsFSharpProject()
+
+    override x.BuildAllPoints() = seq { yield InAzureFunctionsFSharpProject() }
+    override x.CategoryCaption = "Azure (F#)"
+
+[<OptionsPage("RiderAzureFSharpFileTemplatesSettings", "F#", typeof<ProjectModelThemedIcons.Fsharp>)>]
+type RiderAzureFSharpFileTemplatesOptionPage
+        (lifetime, optionsPageContext, settings, storedTemplatesProvider, uiProvider: AzureFSharpProjectScopeCategoryUIProvider,
+         scopeCategoryManager, uiFactory, iconHost, dialogHost) =
+    inherit RiderFileTemplatesOptionPageBase(lifetime, uiProvider, optionsPageContext, settings, storedTemplatesProvider,
+        scopeCategoryManager, uiFactory, iconHost, dialogHost, FSharpProjectFileType.Name)

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/FileTemplates/AzureFSharpScopeProvider.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/FileTemplates/AzureFSharpScopeProvider.fs
@@ -29,7 +29,7 @@ type AzureFSharpScopeProvider() as this =
         let baseItems = base.GetLanguageSpecificScopePoints project
         seq {
             yield! baseItems
-            if project.ProjectProperties.DefaultLanguage = FSharpProjectLanguage.Instance then
+            if project.ProjectProperties :? FSharpProjectProperties then
                 yield InAzureFunctionsFSharpProject()
         }
 

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/settings/RiderFSharpFileTemplatesOptionPage.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/settings/RiderFSharpFileTemplatesOptionPage.kt
@@ -6,3 +6,7 @@ import com.jetbrains.rider.settings.simple.SimpleOptionsPage
 class RiderFSharpFileTemplatesOptionPage : SimpleOptionsPage("F#", "RiderFSharpFileTemplatesSettings"), Configurable.NoScroll {
     override fun getId(): String = "RiderFSharpFileTemplatesSettings"
 }
+
+class RiderAzureFSharpFileTemplatesOptionPage : SimpleOptionsPage("Azure (F#)", "RiderAzureFSharpFileTemplatesSettings"), Configurable.NoScroll {
+    override fun getId(): String = "RiderAzureFSharpFileTemplatesSettings"
+}

--- a/rider-fsharp/src/main/resources/META-INF/plugin.xml
+++ b/rider-fsharp/src/main/resources/META-INF/plugin.xml
@@ -54,6 +54,7 @@
     <applicationConfigurable groupId="language" instance="com.jetbrains.rider.plugins.fsharp.services.settings.FsiOptionsPage" id="Fsi" />
     <applicationConfigurable groupId="language" instance="com.jetbrains.rider.plugins.fsharp.settings.FSharpOptionsPage" id="FSharp" />
     <projectConfigurable parentId="FileTemplatesSettingsId" instance="com.jetbrains.rider.settings.RiderFSharpFileTemplatesOptionPage" groupWeight="-20"/>
+    <projectConfigurable parentId="FileTemplatesSettingsId" instance="com.jetbrains.rider.settings.RiderAzureFSharpFileTemplatesOptionPage" groupWeight="-151"/>
 
     <intentionAction>
       <className>com.jetbrains.rider.plugins.fsharp.services.fsi.SendLineToFsiIntentionAction</className>


### PR DESCRIPTION
This adds an F#-bound Azure scope (and the corresponding Azure Functions scope point), so the [Azure plugin](https://plugins.jetbrains.com/plugin/11220-azure-toolkit-for-rider) will be able to add the templates there.