### PR TITLE
Change the Interactive console view

### DIFF
--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiConsoleRunner.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiConsoleRunner.kt
@@ -19,6 +19,7 @@ import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
 import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.colors.EditorColors
 import com.intellij.openapi.editor.ex.util.EditorUtil
 import com.intellij.openapi.extensions.Extensions
 import com.intellij.openapi.fileTypes.PlainTextLanguage
@@ -47,6 +48,7 @@ import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
 import org.jetbrains.concurrency.resolvedPromise
 import java.io.File
+import javax.swing.BorderFactory
 import javax.swing.event.HyperlinkEvent
 import kotlin.properties.Delegates
 
@@ -234,6 +236,10 @@ class FsiConsoleRunner(sessionInfo: RdFsiSessionInfo, val fsiHost: FsiHost, debu
 
     override fun createConsoleView(): LanguageConsoleView {
         val consoleView = LanguageConsoleBuilder().gutterContentProvider(inputSeparatorGutterContentProvider).build(project, PlainTextLanguage.INSTANCE)
+
+        val consoleEditorBorder = BorderFactory.createMatteBorder(
+                2, 0, 0, 0, consoleView.consoleEditor.colorsScheme.getColor(EditorColors.INDENT_GUIDE_COLOR))
+        consoleView.consoleEditor.component.border = consoleEditorBorder
 
         val historyKeyListener = HistoryKeyListener(fsiHost.project, consoleView.consoleEditor, commandHistory)
         consoleView.consoleEditor.contentComponent.addKeyListener(historyKeyListener)

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiConsoleRunner.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiConsoleRunner.kt
@@ -233,7 +233,7 @@ class FsiConsoleRunner(sessionInfo: RdFsiSessionInfo, val fsiHost: FsiHost, debu
     }
 
     override fun createConsoleView(): LanguageConsoleView {
-        val gutterProvider = object : BasicGutterContentProvider() {
+        val gutterProvider = object : BasicGutterContentProvider(false) {
             override fun beforeEvaluate(e: Editor) = Unit
         }
         val consoleView = LanguageConsoleBuilder().gutterContentProvider(gutterProvider).build(project, PlainTextLanguage.INSTANCE)

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/InputSeparatorGutterContentProvider.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/InputSeparatorGutterContentProvider.kt
@@ -1,0 +1,20 @@
+package com.jetbrains.rider.plugins.fsharp.services.fsi
+
+import com.intellij.execution.console.BasicGutterContentProvider
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+
+class InputSeparatorGutterContentProvider(isLineRelationshipComputable: Boolean)
+    : BasicGutterContentProvider(isLineRelationshipComputable) {
+
+    private val separatorLines = mutableSetOf<Int>()
+
+    override fun doIsShowSeparatorLine(line: Int, editor: Editor, document: Document): Boolean {
+        val actualEditorLine = line + 2
+        return separatorLines.contains(actualEditorLine)
+    }
+
+    fun addLineSeparator(line: Int) {
+        separatorLines.add(line)
+    }
+}


### PR DESCRIPTION
Lines were removed from the history view of the interactive console. Now there are only lines above the input text. Added the border to the editor of the console.

![image](https://user-images.githubusercontent.com/26253351/71182749-b9b81600-2287-11ea-8fc6-a83d2e4fc138.png)
