### PR TITLE
Add indenting formatter rules for bindings and nested module declarations

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Common/src/Util/RegistryUtil.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/Util/RegistryUtil.fs
@@ -33,19 +33,14 @@ type ProtocolSolutionExtensions =
         with _ -> null
 
 [<AbstractClass; Sealed; Extension>]
-type FSharpExperimentalFeaturesEx() =
-    static let getFsModelFlagIfNotEnabled property enabled (solution : ISolution) =
-        if enabled then true else
+type FSharpExperimentalFeaturesEx =
+    [<Extension>]
+    static member FSharpExperimentalFeaturesEnabled(solution: ISolution) =
+        if FSharpRegistryUtil.AllowExperimentalFeaturesCookie.Enabled then true else
 
         match solution.RdFSharpModel() with
         | null -> false
-        | fsModel -> property fsModel
-        
-    [<Extension>]
-    static member FSharpExperimentalFeaturesEnabled(solution: ISolution) =
-        getFsModelFlagIfNotEnabled (fun fsModel -> fsModel.EnableExperimentalFeatures.Value)
-            FSharpRegistryUtil.AllowExperimentalFeaturesCookie.Enabled
-            solution
+        | fsModel -> fsModel.EnableExperimentalFeatures.Value
 
     [<Extension>]
     static member FSharpExperimentalFeaturesEnabled(node: ITreeNode) =
@@ -53,9 +48,11 @@ type FSharpExperimentalFeaturesEx() =
 
     [<Extension>]
     static member FSharpFormatterEnabled(solution: ISolution) =
-        getFsModelFlagIfNotEnabled (fun fsModel -> fsModel.EnableFormatter.Value)
-            FSharpRegistryUtil.AllowFormatterCookie.Enabled
-            solution
+        if FSharpRegistryUtil.AllowFormatterCookie.Enabled then true else
+
+        match solution.RdFSharpModel() with
+        | null -> false
+        | fsModel -> fsModel.EnableFormatter.Value
 
     [<Extension>]
     static member FSharpFormatterEnabled(node: ITreeNode) =

--- a/ReSharper.FSharp/src/FSharp.Psi/src/CodeFormatter/FSharpCodeFormatter.cs
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/CodeFormatter/FSharpCodeFormatter.cs
@@ -70,7 +70,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Services.Formatter
       if (task.FirstElement == null)
         return new TreeRange(firstElement, lastElement);
 
-      if (!firstElement.FSharpExperimentalFeaturesEnabled())
+      if (!firstElement.FSharpFormatterEnabled())
         return new TreeRange(firstElement, lastElement);
 
       var formatterSettings = GetFormattingSettings(task.FirstElement, parameters);

--- a/ReSharper.FSharp/src/FSharp.Psi/src/CodeFormatter/FSharpCodeFormatterInfoProvider.cs
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/CodeFormatter/FSharpCodeFormatterInfoProvider.cs
@@ -1,7 +1,10 @@
+using System.Linq;
 using JetBrains.Application.Settings;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Plugins.FSharp.Psi;
+using JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Tree;
 using JetBrains.ReSharper.Psi;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Tree;
 using JetBrains.ReSharper.Psi.Impl.CodeStyle;
 
 namespace JetBrains.ReSharper.Plugins.FSharp.Services.Formatter
@@ -12,8 +15,32 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Services.Formatter
   {
     public FSharpFormatterInfoProvider(ISettingsSchema settingsSchema) : base(settingsSchema)
     {
+      var bindingAndModuleDeclIndentingRulesParameters = new[]
+      {
+        ("NestedModuleDeclaration", ElementType.NESTED_MODULE_DECLARATION, NestedModuleDeclaration.MODULE_MEMBER),
+        ("TopBinding", ElementType.TOP_BINDING, TopBinding.CHAMELEON_EXPR),
+        ("LocalBinding", ElementType.LOCAL_BINDING, LocalBinding.EXPR),
+      };
+
+      lock (this)
+      {
+        bindingAndModuleDeclIndentingRulesParameters
+          .ToList()
+          .ForEach(DescribeSimpleIndentingRule);
+      }
     }
 
     public override ProjectFileType MainProjectFileType => FSharpProjectFileType.Instance;
+
+    private void DescribeSimpleIndentingRule((string name, CompositeNodeType parentType, short childRole) parameters)
+    {
+      Describe<IndentingRule>()
+        .Name(parameters.name + "Indent")
+        .Where(
+          Parent().HasType(parameters.parentType),
+          Node().HasRole(parameters.childRole))
+        .Return(IndentType.External)
+        .Build();
+    }
   }
 }

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Local binding indent 01 - No indent.fs
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Local binding indent 01 - No indent.fs
@@ -1,0 +1,5 @@
+module Module
+
+let a =
+  let b =
+  ()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Local binding indent 01 - No indent.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Local binding indent 01 - No indent.fs.gold
@@ -1,0 +1,5 @@
+﻿module Module
+
+let a =
+  let b =
+    ()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Local binding indent 02 - Correct indent.fs
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Local binding indent 02 - Correct indent.fs
@@ -1,0 +1,5 @@
+module Module
+
+let a =
+  let b =
+    ()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Local binding indent 02 - Correct indent.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Local binding indent 02 - Correct indent.fs.gold
@@ -1,0 +1,5 @@
+﻿module Module
+
+let a =
+  let b =
+    ()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Local binding indent 03 - Big indent.fs
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Local binding indent 03 - Big indent.fs
@@ -1,0 +1,5 @@
+module Module
+
+let a =
+  let b =
+           ()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Local binding indent 03 - Big indent.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Local binding indent 03 - Big indent.fs.gold
@@ -1,0 +1,5 @@
+﻿module Module
+
+let a =
+  let b =
+    ()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Nested module indent 01 - No indent.fs
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Nested module indent 01 - No indent.fs
@@ -1,0 +1,4 @@
+namespace Namespace
+
+module Module =
+()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Nested module indent 01 - No indent.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Nested module indent 01 - No indent.fs.gold
@@ -1,0 +1,4 @@
+﻿namespace Namespace
+
+module Module =
+  ()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Nested module indent 02 - Correct indent.fs
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Nested module indent 02 - Correct indent.fs
@@ -1,0 +1,4 @@
+namespace Namespace
+
+module Module =
+  ()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Nested module indent 02 - Correct indent.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Nested module indent 02 - Correct indent.fs.gold
@@ -1,0 +1,4 @@
+﻿namespace Namespace
+
+module Module =
+  ()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Nested module indent 03 - Big indent.fs
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Nested module indent 03 - Big indent.fs
@@ -1,0 +1,4 @@
+namespace Namespace
+
+module Module =
+        ()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Nested module indent 03 - Big indent.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Nested module indent 03 - Big indent.fs.gold
@@ -1,0 +1,4 @@
+﻿namespace Namespace
+
+module Module =
+  ()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Top binding indent 01 - No indent.fs
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Top binding indent 01 - No indent.fs
@@ -1,0 +1,4 @@
+module Module
+
+let _ =
+()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Top binding indent 01 - No indent.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Top binding indent 01 - No indent.fs.gold
@@ -1,0 +1,4 @@
+﻿module Module
+
+let _ =
+  ()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Top binding indent 02 - Correct indent.fs
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Top binding indent 02 - Correct indent.fs
@@ -1,0 +1,4 @@
+module Module
+
+let _ =
+  ()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Top binding indent 02 - Correct indent.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Top binding indent 02 - Correct indent.fs.gold
@@ -1,0 +1,4 @@
+﻿module Module
+
+let _ =
+  ()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Top binding indent 03 - Big indent.fs
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Top binding indent 03 - Big indent.fs
@@ -1,0 +1,4 @@
+module Module
+
+let _ =
+        ()

--- a/ReSharper.FSharp/test/data/features/service/codeFormatter/Top binding indent 03 - Big indent.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/codeFormatter/Top binding indent 03 - Big indent.fs.gold
@@ -1,0 +1,4 @@
+﻿module Module
+
+let _ =
+  ()

--- a/ReSharper.FSharp/test/src/FSharp.Tests/FSharp.Tests.fsproj
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/FSharp.Tests.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="Service\FSharpElementFactoryTest.fs" />
     <Compile Include="Service\FSharpNamingTest.fs" />
     <Compile Include="Service\FSharpMetadataReaderTest.fs" />
+    <Compile Include="Service\FSharpCodeFormatterTest.fs" />
     <Compile Include="Cache\CSharpResolveTest.fs" />
     <Compile Include="Cache\SymbolCacheTest.fs" />
     <Compile Include="Parsing\FSharpLexerTest.fs" />

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Service/FSharpCodeFormatterTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Service/FSharpCodeFormatterTest.fs
@@ -1,0 +1,28 @@
+namespace JetBrains.ReSharper.Plugins.FSharp.Tests.Features
+
+open JetBrains.ReSharper.FeaturesTestFramework.Formatter
+open JetBrains.ReSharper.Plugins.FSharp.Psi
+open JetBrains.ReSharper.Plugins.FSharp.Tests
+open NUnit.Framework
+
+[<FSharpTest>]
+type FSharpCodeFormatterTest() =
+    inherit CodeFormatterWithExplicitSettingsTestBase<FSharpLanguage>()
+
+    override x.RelativeTestDataPath = "features/service/codeFormatter"
+
+    override x.DoNamedTest() =
+        use cookie = FSharpRegistryUtil.AllowFormatterCookie.Create()
+        base.DoNamedTest()
+
+    [<Test>] member x.``Top binding indent 01 - No indent``() = x.DoNamedTest()
+    [<Test>] member x.``Top binding indent 02 - Correct indent``() = x.DoNamedTest()
+    [<Test>] member x.``Top binding indent 03 - Big indent``() = x.DoNamedTest()
+
+    [<Test>] member x.``Local binding indent 01 - No indent``() = x.DoNamedTest()
+    [<Test>] member x.``Local binding indent 02 - Correct indent``() = x.DoNamedTest()
+    [<Test>] member x.``Local binding indent 03 - Big indent``() = x.DoNamedTest()
+
+    [<Test>] member x.``Nested module indent 01 - No indent``() = x.DoNamedTest()
+    [<Test>] member x.``Nested module indent 02 - Correct indent``() = x.DoNamedTest()
+    [<Test>] member x.``Nested module indent 03 - Big indent``() = x.DoNamedTest()

--- a/rider-fsharp/protocol/src/kotlin/model/RdFSharpModel.kt
+++ b/rider-fsharp/protocol/src/kotlin/model/RdFSharpModel.kt
@@ -42,5 +42,6 @@ object RdFSharpModel : Ext(SolutionModel.Solution) {
         field("fSharpInteractiveHost", RdFSharpInteractiveHost)
         field("fSharpCompilerServiceHost", RdFSharpCompilerServiceHost)
         property("enableExperimentalFeatures", bool)
+        property("enableFormatter", bool)
     }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/FSharpHost.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/FSharpHost.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.util.registry.RegistryValue
 import com.intellij.openapi.util.registry.RegistryValueListener
+import com.jetbrains.rd.util.reactive.IOptProperty
 import com.jetbrains.rdclient.util.idea.LifetimedProjectComponent
 import com.jetbrains.rider.model.rdFSharpModel
 import com.jetbrains.rider.projectView.solution
@@ -12,15 +13,21 @@ class FSharpHost(project: Project) : LifetimedProjectComponent(project) {
     private val fSharpModel = project.solution.rdFSharpModel
 
     companion object {
-        const val registryKey = "rider.fsharp.experimental"
+        const val experimentalFeaturesRegistryKey = "rider.fsharp.experimental"
+        const val formatterRegistryKey = "rider.fsharp.formatter"
     }
 
     init {
+        initRegistryValue(experimentalFeaturesRegistryKey, fSharpModel.enableExperimentalFeatures)
+        initRegistryValue(formatterRegistryKey, fSharpModel.enableFormatter)
+    }
+
+    private fun initRegistryValue(registryKey: String, property: IOptProperty<Boolean>) {
         val registryValue = Registry.get(registryKey)
-        fSharpModel.enableExperimentalFeatures.set(registryValue.asBoolean())
+        property.set(registryValue.asBoolean())
         registryValue.addListener(object : RegistryValueListener.Adapter() {
             override fun afterValueChanged(value: RegistryValue) {
-                fSharpModel.enableExperimentalFeatures.set(value.asBoolean())
+                property.set(value.asBoolean())
             }
         }, project)
     }

--- a/rider-fsharp/src/main/resources/META-INF/plugin.xml
+++ b/rider-fsharp/src/main/resources/META-INF/plugin.xml
@@ -84,6 +84,7 @@
     </intentionAction>
 
     <registryKey key="rider.fsharp.experimental" description="Enable experimental F# features" defaultValue="false" restartRequired="false"/>
+    <registryKey key="rider.fsharp.formatter" description="Enable F# code formatter" defaultValue="false" restartRequired="false"/>
   </extensions>
 
   <actions>


### PR DESCRIPTION
Added some formatter rules for indents inside
- bindings
- nested modules

Also added registry value to enable formatter.