### PR TITLE
Non-Windows platforms care about casing, lowercase is correct in this case

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Features/FSharp.Psi.Features.fsproj
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/FSharp.Psi.Features.fsproj
@@ -22,7 +22,7 @@
     <Compile Include="src\CodeStructure\FSharpCodeStructure.fs" />
     <Compile Include="src\Daemon\Highlightings\FSharpErrorUtil.fs" />
     <Compile Include="src\Daemon\Highlightings\ErrorHighlightings.fs" />
-    <Compile Include="Src\Daemon\Highlightings\CommonErrors.Generated.fs">
+    <Compile Include="src\Daemon\Highlightings\CommonErrors.Generated.fs">
       <DependentUpon>CommonErrors.xml</DependentUpon>
     </Compile>
     <ErrorsGen Include="src\Daemon\Highlightings\CommonErrors.xml">


### PR DESCRIPTION
Incorrect capitalisation of `Src` causes the build to try to reference a generated file which doesn't exist - Windows gets away with it by not caring about casing...