### PR TITLE
Show background task in UI when FCS reactor is busy

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Features/FSharp.Psi.Features.fsproj
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/FSharp.Psi.Features.fsproj
@@ -163,6 +163,7 @@
     <Compile Include="src\LanguageService\FSharpQuickDefinitionService.fs" />
     <Compile Include="src\LanguageService\SandboxDocumentLanguageSupportFSharpScript.fs" />
     <Compile Include="src\FSharpTypingAssist.fs" />
+    <Compile Include="src\FcsReactorMonitor.fs" />
     <Compile Include="src\ZoneMarker.fs" />
   </ItemGroup>
 

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Stages/FSharpIdentifierTooltipProvider.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Stages/FSharpIdentifierTooltipProvider.fs
@@ -28,7 +28,7 @@ type FSharpIdentifierTooltipProvider(lifetime, solution, presenter, xmlDocServic
 
     let [<Literal>] opName = "FSharpIdentifierTooltipProvider"
 
-    static member GetFSharpToolTipText(checkResults: FSharpCheckFileResults, token: FSharpIdentifierToken) =
+    static member GetFSharpToolTipText(userOpName: string, checkResults: FSharpCheckFileResults, token: FSharpIdentifierToken) =
         // todo: fix getting qualifiers
         let tokenNames = [token.Name]
 
@@ -38,7 +38,7 @@ type FSharpIdentifierTooltipProvider(lifetime, solution, presenter, xmlDocServic
         use cookie = CompilationContextCookie.GetOrCreate(sourceFile.GetPsiModule().GetContextFromModule())
 
         // todo: provide tooltip for #r strings in fsx, should pass String tag
-        let getTooltip = checkResults.GetStructuredToolTipText(int coords.Line + 1, int coords.Column, lineText, tokenNames, FSharpTokenTag.Identifier)
+        let getTooltip = checkResults.GetStructuredToolTipText(int coords.Line + 1, int coords.Column, lineText, tokenNames, FSharpTokenTag.Identifier, userOpName)
         getTooltip.RunAsTask()
 
     override x.GetTooltip(highlighter) =
@@ -67,7 +67,7 @@ type FSharpIdentifierTooltipProvider(lifetime, solution, presenter, xmlDocServic
         | Some results ->
 
         let result = List()
-        let (FSharpToolTipText layouts) = FSharpIdentifierTooltipProvider.GetFSharpToolTipText(results.CheckResults, token)
+        let (FSharpToolTipText layouts) = FSharpIdentifierTooltipProvider.GetFSharpToolTipText(opName, results.CheckResults, token)
         
         layouts |> List.iter (function
             | FSharpStructuredToolTipElement.None

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Stages/PipeChainTypeHintStage.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Stages/PipeChainTypeHintStage.fs
@@ -81,7 +81,7 @@ type PipeChainHighlightingProcess(logger: ILogger, fsFile, settings: IContextBou
         for token, exprToAdorn in exprs do
             if daemonProcess.InterruptFlag then raise <| OperationCanceledException()
 
-            let (FSharpToolTipText layouts) = FSharpIdentifierTooltipProvider.GetFSharpToolTipText(checkResults, token)
+            let (FSharpToolTipText layouts) = FSharpIdentifierTooltipProvider.GetFSharpToolTipText(opName, checkResults, token)
 
             // The |> operator should have one overload and two type parameters
             match layouts with

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/FcsReactorMonitor.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/FcsReactorMonitor.fs
@@ -25,7 +25,7 @@ type FcsReactorMonitor
 
     /// How long after the reactor becoming busy that the background task should be shown
     let showDelay =
-        if configurations.IsInternalMode() then 1.0 else 5.0
+        if configurations.IsInternalMode() then 3.0 else 5.0
         |> TimeSpan.FromSeconds
 
     /// How long after the reactor becoming free that the background task should be hidden
@@ -92,7 +92,10 @@ type FcsReactorMonitor
         showBackgroundTask.WhenTrue(lifetime, Action<_> createNewTask)
 
         isReactorBusy.WhenTrue(lifetime, fun _ -> showBackgroundTask.SetValue true |> ignore)
-        isReactorBusy.WhenFalse(lifetime, fun lt -> threading.QueueAt(lt, "FcsReactorMonitor.HideTask", hideDelay, fun () -> showBackgroundTask.SetValue false |> ignore))
+
+        isReactorBusy.WhenFalse(lifetime, fun lt ->
+            threading.QueueAt(lt, "FcsReactorMonitor.HideTask", hideDelay, fun () ->
+                showBackgroundTask.SetValue false |> ignore))
 
         // Start listening for trace events
         Trace.Listeners.Add(this) |> ignore

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/FcsReactorMonitor.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/FcsReactorMonitor.fs
@@ -1,0 +1,112 @@
+module JetBrains.ReSharper.Plugins.FSharp.Psi.Features.FcsReactorMonitor
+
+open System
+open System.Diagnostics
+open System.Text.RegularExpressions
+open JetBrains.Application.Threading
+open JetBrains.DataFlow
+open JetBrains.Lifetimes
+open JetBrains.ProjectModel
+open JetBrains.ReSharper.Host.Features.BackgroundTasks
+
+[<SolutionComponent>]
+type FcsReactorMonitor(lifetime: Lifetime, locks: IShellLocks, backgroundTaskHost: RiderBackgroundTaskHost, threading: IThreading) as this =
+    inherit TraceListener("FcsReactorMonitor")
+
+    /// How long before the FCS becoming busy that the background task should be shown
+    let showDelay = TimeSpan.FromSeconds 1.0
+
+    /// How long after the FCS becoming free that the background task should be hidden
+    let hideDelay = TimeSpan.FromSeconds 0.5
+
+    let isReactorBusy = new Property<bool>("isReactorBusy")
+    let operationCounter = new Property<int64>("operationCounter")
+    let queueLength = new Property<int>("queueLength")
+
+    let taskHeader = new Property<string>("header")
+    let taskDescription = new Property<string>("description")
+    let taskVisible = new Property<bool>("taskVisible")
+
+    let opStartRegex = Regex(@"--> (.+), remaining (\d+)$", RegexOptions.Compiled)
+    let enqueueRegex = Regex(@"enqueue .+, length (\d+)$", RegexOptions.Compiled)
+
+    let createNewTask (activeLifetime: Lifetime) =
+        locks.Dispatcher.AssertAccess()
+
+        let task =
+            RiderBackgroundTaskBuilder.Create()
+                .WithTitle("F# Compiler Service")
+                .WithHeader(taskHeader)
+                .WithDescription(taskDescription)
+                .AsIndeterminate()
+                .AsNonCancelable()
+                .Build()
+
+        // Show the background task after we've been busy for some time
+        threading.QueueAt(
+            activeLifetime,
+            "FcsReactorMonitor.AddNewTask",
+            showDelay,
+            fun () -> backgroundTaskHost.AddNewTask(activeLifetime, task)
+        )
+
+    let onOperationEnqueue (remaining: int) =
+        locks.Dispatcher.AssertAccess()
+
+        // Trace is sent _before_ operation is enqueued, so it's always one behind
+        queueLength.SetValue (remaining + 1) |> ignore
+
+    let onOperationStart (opDescription: string) (remaining: int) =
+        locks.Dispatcher.AssertAccess()
+
+        operationCounter.SetValue (operationCounter.Value + 1L) |> ignore
+        taskHeader.SetValue opDescription |> ignore
+        queueLength.SetValue remaining |> ignore
+        isReactorBusy.SetValue true |> ignore
+
+    let onOperationEnd () =
+        locks.Dispatcher.AssertAccess()
+        isReactorBusy.SetValue false |> ignore
+
+    let updateTaskDescription () =
+        let queueLength = queueLength.Value
+
+        if queueLength <= 0 then ""
+        else sprintf " + %d queued" queueLength
+        |> sprintf "#%d%s" operationCounter.Value
+        |> taskDescription.SetValue
+        |> ignore
+
+    let onTrace (message: string) =
+        // todo: this is horrible. add a proper IReactorListener interface in FCS instead
+
+        if message.Contains "<--" then
+            locks.Dispatcher.BeginInvoke(lifetime, "FcsReactorMonitor.OnOperationEnd", onOperationEnd)
+        else
+
+        let enqueueMatch = enqueueRegex.Match(message)
+        if enqueueMatch.Success then
+            locks.Dispatcher.BeginInvoke(lifetime, "FcsReactorMonitor.OnOperationEnqueue", fun () -> onOperationEnqueue (Int32.Parse (enqueueMatch.Groups.[1].Value)))
+
+        else
+        let opStartMatch = opStartRegex.Match(message)
+        if opStartMatch.Success then
+            locks.Dispatcher.BeginInvoke(lifetime, "FcsReactorMonitor.OnOperationStart", fun () -> onOperationStart (opStartMatch.Groups.[1].Value) (Int32.Parse (opStartMatch.Groups.[2].Value)))
+
+    do
+        // todo: are we running in internal mode?
+
+        taskVisible.WhenTrue(lifetime, Action<_> createNewTask)
+
+        isReactorBusy.WhenTrue(lifetime, fun _ -> taskVisible.SetValue true |> ignore)
+        isReactorBusy.WhenFalse(lifetime, fun lt -> threading.QueueAt(lt, "FcsReactorMonitor.HideTask", hideDelay, fun () -> taskVisible.SetValue false |> ignore))
+
+        operationCounter.Change.Advise(lifetime, updateTaskDescription)
+        queueLength.Change.Advise(lifetime, updateTaskDescription)
+
+        // Start listening for trace events
+        Trace.Listeners.Add(this) |> ignore
+        lifetime.OnTermination(fun () -> Trace.Listeners.Remove(this)) |> ignore
+
+    override x.Write(message: string) = ()
+    override x.WriteLine(message: string) = if message.StartsWith "Reactor:" then onTrace message


### PR DESCRIPTION
![loading-file-2](https://user-images.githubusercontent.com/64654/82764792-78fd9380-9e09-11ea-9603-43aff1074db4.gif)

**Todo**:

- [x] Only show in internal mode/have a longer delay before showing
- [ ] Integrate properly with FCS instead of regex matching on trace messages