### PR TITLE
Change history viewer of the interactive console.

### DIFF
--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiConsoleIndicatorRenderer.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiConsoleIndicatorRenderer.kt
@@ -1,0 +1,11 @@
+package com.jetbrains.rider.plugins.fsharp.services.fsi
+
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+
+class FsiConsoleIndicatorRenderer(private val iconWithTooltip: IconWithTooltip) : GutterIconRenderer() {
+    override fun getIcon() = iconWithTooltip.icon
+    override fun getTooltipText() = iconWithTooltip.tooltip
+
+    override fun equals(other: Any?) = icon == (other as? FsiConsoleIndicatorRenderer)?.icon
+    override fun hashCode() = icon.hashCode()
+}

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiConsoleRunner.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiConsoleRunner.kt
@@ -20,7 +20,6 @@ import com.intellij.notification.Notifications
 import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.colors.EditorColors
-import com.intellij.openapi.editor.ex.util.EditorUtil
 import com.intellij.openapi.extensions.Extensions
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
@@ -29,15 +28,19 @@ import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.project.isDirectoryBased
+import com.intellij.ui.Gray
+import com.intellij.ui.JBColor
 import com.intellij.util.containers.ContainerUtil
 import com.intellij.util.ui.UIUtil
 import com.intellij.xdebugger.XDebuggerManager
 import com.intellij.xdebugger.attach.LocalAttachHost
 import com.intellij.xdebugger.attach.XAttachDebuggerProvider
+import com.jetbrains.rd.platform.util.application
 import com.jetbrains.rdclient.util.idea.pumpMessages
 import com.jetbrains.rider.debugger.DotNetDebugProcess
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpScriptLanguage
-import com.jetbrains.rider.model.*
+import com.jetbrains.rider.model.RdFsiRuntime
+import com.jetbrains.rider.model.RdFsiSessionInfo
 import com.jetbrains.rider.plugins.fsharp.FSharpIcons
 import com.jetbrains.rider.runtime.RiderDotNetActiveRuntimeHost
 import com.jetbrains.rider.runtime.mono.MonoRuntime
@@ -50,7 +53,6 @@ import java.time.Duration
 import javax.swing.BorderFactory
 import javax.swing.event.HyperlinkEvent
 import kotlin.properties.Delegates
-import com.jetbrains.rd.platform.util.application
 
 class FsiConsoleRunner(sessionInfo: RdFsiSessionInfo, val fsiHost: FsiHost, debug: Boolean)
     : AbstractConsoleRunnerWithHistory<LanguageConsoleView>(fsiHost.project, fsiTitle, null) {
@@ -72,6 +74,8 @@ class FsiConsoleRunner(sessionInfo: RdFsiSessionInfo, val fsiHost: FsiHost, debu
             .withExePath(sessionInfo.fsiPath)
             .withParameters(fsiArgs)
     private val inputSeparatorGutterContentProvider = InputSeparatorGutterContentProvider(true)
+
+    private val fsiInputOutputProcessor = FsiInputOutputProcessor(this)
 
     init {
         val runtimeHost = project.getComponent<RiderDotNetActiveRuntimeHost>()
@@ -149,9 +153,7 @@ class FsiConsoleRunner(sessionInfo: RdFsiSessionInfo, val fsiHost: FsiHost, debu
         UIUtil.invokeLaterIfNeeded {
             inputSeparatorGutterContentProvider.addLineSeparator(consoleView.historyViewer.document.lineCount)
 
-            consoleView.print(visibleText, ConsoleViewContentType.USER_INPUT)
-            consoleView.print("\n", ConsoleViewContentType.NORMAL_OUTPUT)
-            EditorUtil.scrollToTheEnd(consoleView.historyViewer)
+            fsiInputOutputProcessor.printInputText(visibleText, ConsoleViewContentType.USER_INPUT)
 
             commandHistory.addEntry(CommandHistory.Entry(visibleText, fsiText))
 
@@ -236,6 +238,21 @@ class FsiConsoleRunner(sessionInfo: RdFsiSessionInfo, val fsiHost: FsiHost, debu
         return actionList
     }
 
+    override fun initAndRun() {
+        super.initAndRun()
+
+        setupGutters()
+    }
+
+    private fun setupGutters(){
+        val historyEditor = consoleView.historyViewer
+        historyEditor.settings.isLineMarkerAreaShown = true
+        historyEditor.settings.isFoldingOutlineShown = true
+        historyEditor.gutterComponentEx.setPaintBackground(true)
+
+        historyEditor.colorsScheme.setColor(EditorColors.GUTTER_BACKGROUND, JBColor(Gray.xF2, Gray.x41))
+    }
+
     override fun createConsoleView(): LanguageConsoleView {
         var createdConsoleView : LanguageConsoleView? = null
 
@@ -257,7 +274,7 @@ class FsiConsoleRunner(sessionInfo: RdFsiSessionInfo, val fsiHost: FsiHost, debu
     }
 
     override fun createProcessHandler(process: Process): OSProcessHandler {
-        val fsiProcessHandler = FsiProcessHandler(process, cmdLine.commandLineString)
+        val fsiProcessHandler = FsiProcessHandler(fsiInputOutputProcessor, process, cmdLine.commandLineString)
 
         val sandboxInfoUpdater = FsiSandboxInfoUpdater(fsiHost.project, consoleView.consoleEditor, commandHistory)
         fsiProcessHandler.addSandboxInfoUpdater(sandboxInfoUpdater)

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiIcons.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiIcons.kt
@@ -8,4 +8,5 @@ data class IconWithTooltip(val icon: Icon, val tooltip: String?)
 object FsiIcons {
     val COMMAND_MARKER = IconWithTooltip(AllIcons.Actions.Execute, "Executed command")
     val RESULT = IconWithTooltip(AllIcons.Vcs.Equal, "Result")
+    val ERROR = IconWithTooltip(AllIcons.General.Warning, "Error")
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiIcons.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiIcons.kt
@@ -1,0 +1,11 @@
+package com.jetbrains.rider.plugins.fsharp.services.fsi
+
+import com.intellij.icons.AllIcons
+import javax.swing.Icon
+
+data class IconWithTooltip(val icon: Icon, val tooltip: String?)
+
+object FsiIcons {
+    val COMMAND_MARKER = IconWithTooltip(AllIcons.Actions.Execute, "Executed command")
+    val RESULT = IconWithTooltip(AllIcons.Vcs.Equal, "Result")
+}

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiInputOutputProcessor.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiInputOutputProcessor.kt
@@ -26,7 +26,17 @@ class FsiInputOutputProcessor(private val fsiRunner: FsiConsoleRunner) {
         return Pair(startOffset, endOffset)
     }
 
-    private fun fsiIconWithTooltipOnOutputText() : IconWithTooltip? = if (nextOutputTextIsFirst) FsiIcons.RESULT else null
+    private fun fsiIconWithTooltipOnOutputText(outputType: ConsoleViewContentType) : IconWithTooltip? {
+        if (nextOutputTextIsFirst)
+        {
+            when (outputType) {
+                ConsoleViewContentType.NORMAL_OUTPUT -> return FsiIcons.RESULT
+                ConsoleViewContentType.ERROR_OUTPUT -> return FsiIcons.ERROR
+            }
+        }
+
+        return null
+    }
 
     fun printInputText(text: String, outputType: ConsoleViewContentType) {
         printText(text + "\n", FsiIcons.COMMAND_MARKER, fSharpSyntaxHighlighter, outputType)
@@ -40,7 +50,7 @@ class FsiInputOutputProcessor(private val fsiRunner: FsiConsoleRunner) {
             printOutputInitialText(text, outputType)
         }
         else {
-            val fsiResultIconWithTooltip = fsiIconWithTooltipOnOutputText()
+            val fsiResultIconWithTooltip = fsiIconWithTooltipOnOutputText(outputType)
 
             when (outputType) {
                 ConsoleViewContentType.NORMAL_OUTPUT ->

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiInputOutputProcessor.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiInputOutputProcessor.kt
@@ -11,7 +11,7 @@ import com.intellij.openapi.editor.markup.HighlighterTargetArea
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.highlighting.FSharpSyntaxHighlighter
 
 class FsiInputOutputProcessor(private val fsiRunner: FsiConsoleRunner) {
-    private var isInitialState = true
+    private var isInitialText = true
     private var nextOutputTextIsFirst = true
 
     private val fSharpSyntaxHighlighter = FSharpSyntaxHighlighter()
@@ -32,12 +32,11 @@ class FsiInputOutputProcessor(private val fsiRunner: FsiConsoleRunner) {
         printText(text + "\n", FsiIcons.COMMAND_MARKER, fSharpSyntaxHighlighter, outputType)
         EditorUtil.scrollToTheEnd(fsiRunner.consoleView.historyViewer)
 
-        isInitialState = false
         nextOutputTextIsFirst = true
     }
 
     fun printOutputText(text: String, outputType: ConsoleViewContentType) {
-        if (isInitialState) {
+        if (isInitialText) {
             printOutputInitialText(text, outputType)
         }
         else {
@@ -76,5 +75,9 @@ class FsiInputOutputProcessor(private val fsiRunner: FsiConsoleRunner) {
 
     private fun printOutputInitialText(text: String, outputType: ConsoleViewContentType)  = WriteCommandAction.runWriteCommandAction(fsiRunner.project){
         fsiRunner.consoleView.print(text, outputType)
+    }
+    
+    fun onServerPrompt() {
+        isInitialText = false
     }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiInputOutputProcessor.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiInputOutputProcessor.kt
@@ -26,9 +26,8 @@ class FsiInputOutputProcessor(private val fsiRunner: FsiConsoleRunner) {
         return Pair(startOffset, endOffset)
     }
 
-    private fun fsiIconWithTooltipOnOutputText(outputType: ConsoleViewContentType) : IconWithTooltip? {
-        if (nextOutputTextIsFirst)
-        {
+    private fun fsiIconWithTooltipOnOutputText(outputType: ConsoleViewContentType): IconWithTooltip? {
+        if (nextOutputTextIsFirst) {
             when (outputType) {
                 ConsoleViewContentType.NORMAL_OUTPUT -> return FsiIcons.RESULT
                 ConsoleViewContentType.ERROR_OUTPUT -> return FsiIcons.ERROR
@@ -48,8 +47,7 @@ class FsiInputOutputProcessor(private val fsiRunner: FsiConsoleRunner) {
     fun printOutputText(text: String, outputType: ConsoleViewContentType) {
         if (isInitialText) {
             printOutputInitialText(text, outputType)
-        }
-        else {
+        } else {
             val fsiResultIconWithTooltip = fsiIconWithTooltipOnOutputText(outputType)
 
             when (outputType) {
@@ -63,30 +61,31 @@ class FsiInputOutputProcessor(private val fsiRunner: FsiConsoleRunner) {
         }
     }
 
-    private fun printText(text: String, iconWithTooltip: IconWithTooltip?, highlighter: FSharpSyntaxHighlighter?, outputType: ConsoleViewContentType)
-                = WriteCommandAction.runWriteCommandAction(fsiRunner.project) {
-        val (startOffset, endOffset) = textOffsets(text)
+    private fun printText(text: String, iconWithTooltip: IconWithTooltip?, highlighter: FSharpSyntaxHighlighter?,
+                          outputType: ConsoleViewContentType) =
+            WriteCommandAction.runWriteCommandAction(fsiRunner.project) {
+                val (startOffset, endOffset) = textOffsets(text)
 
-        if (highlighter == null) {
-            fsiRunner.consoleView.print(text, outputType)
-        }
-        else {
-            ConsoleViewUtil.printWithHighlighting(fsiRunner.consoleView, text, highlighter)
-        }
+                if (highlighter == null) {
+                    fsiRunner.consoleView.print(text, outputType)
+                } else {
+                    ConsoleViewUtil.printWithHighlighting(fsiRunner.consoleView, text, highlighter)
+                }
 
-        (fsiRunner.consoleView as LanguageConsoleImpl).flushDeferredText()
+                (fsiRunner.consoleView as LanguageConsoleImpl).flushDeferredText()
 
-        if (iconWithTooltip == null) return@runWriteCommandAction
+                if (iconWithTooltip == null) return@runWriteCommandAction
 
-        fsiRunner.consoleView.historyViewer.markupModel.addRangeHighlighter(
-                startOffset, endOffset, HighlighterLayer.LAST, null, HighlighterTargetArea.LINES_IN_RANGE
-        ).apply { gutterIconRenderer = FsiConsoleIndicatorRenderer(iconWithTooltip) }
-    }
+                fsiRunner.consoleView.historyViewer.markupModel.addRangeHighlighter(
+                        startOffset, endOffset, HighlighterLayer.LAST, null, HighlighterTargetArea.LINES_IN_RANGE
+                ).apply { gutterIconRenderer = FsiConsoleIndicatorRenderer(iconWithTooltip) }
+            }
 
-    private fun printOutputInitialText(text: String, outputType: ConsoleViewContentType)  = WriteCommandAction.runWriteCommandAction(fsiRunner.project){
-        fsiRunner.consoleView.print(text, outputType)
-    }
-    
+    private fun printOutputInitialText(text: String, outputType: ConsoleViewContentType) =
+            WriteCommandAction.runWriteCommandAction(fsiRunner.project) {
+                fsiRunner.consoleView.print(text, outputType)
+            }
+
     fun onServerPrompt() {
         isInitialText = false
     }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiInputOutputProcessor.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiInputOutputProcessor.kt
@@ -1,0 +1,80 @@
+package com.jetbrains.rider.plugins.fsharp.services.fsi
+
+import com.intellij.execution.console.LanguageConsoleImpl
+import com.intellij.execution.impl.ConsoleViewImpl
+import com.intellij.execution.impl.ConsoleViewUtil
+import com.intellij.execution.ui.ConsoleViewContentType
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.editor.ex.util.EditorUtil
+import com.intellij.openapi.editor.markup.HighlighterLayer
+import com.intellij.openapi.editor.markup.HighlighterTargetArea
+import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.highlighting.FSharpSyntaxHighlighter
+
+class FsiInputOutputProcessor(private val fsiRunner: FsiConsoleRunner) {
+    private var isInitialState = true
+    private var nextOutputTextIsFirst = true
+
+    private val fSharpSyntaxHighlighter = FSharpSyntaxHighlighter()
+
+    private fun textOffsets(text: String): Pair<Int, Int> {
+        (fsiRunner.consoleView as ConsoleViewImpl).flushDeferredText()
+
+        val historyEditor = fsiRunner.consoleView.historyViewer
+        val startOffset = historyEditor.document.textLength
+        val endOffset = startOffset + text.length
+
+        return Pair(startOffset, endOffset)
+    }
+
+    private fun fsiIconWithTooltipOnOutputText() : IconWithTooltip? = if (nextOutputTextIsFirst) FsiIcons.RESULT else null
+
+    fun printInputText(text: String, outputType: ConsoleViewContentType) {
+        printText(text + "\n", FsiIcons.COMMAND_MARKER, fSharpSyntaxHighlighter, outputType)
+        EditorUtil.scrollToTheEnd(fsiRunner.consoleView.historyViewer)
+
+        isInitialState = false
+        nextOutputTextIsFirst = true
+    }
+
+    fun printOutputText(text: String, outputType: ConsoleViewContentType) {
+        if (isInitialState) {
+            printOutputInitialText(text, outputType)
+        }
+        else {
+            val fsiResultIconWithTooltip = fsiIconWithTooltipOnOutputText()
+
+            when (outputType) {
+                ConsoleViewContentType.NORMAL_OUTPUT ->
+                    printText(text, fsiResultIconWithTooltip, fSharpSyntaxHighlighter, outputType)
+                ConsoleViewContentType.ERROR_OUTPUT ->
+                    printText(text, fsiResultIconWithTooltip, null, outputType)
+            }
+
+            nextOutputTextIsFirst = false
+        }
+    }
+
+    private fun printText(text: String, iconWithTooltip: IconWithTooltip?, highlighter: FSharpSyntaxHighlighter?, outputType: ConsoleViewContentType)
+                = WriteCommandAction.runWriteCommandAction(fsiRunner.project) {
+        val (startOffset, endOffset) = textOffsets(text)
+
+        if (highlighter == null) {
+            fsiRunner.consoleView.print(text, outputType)
+        }
+        else {
+            ConsoleViewUtil.printWithHighlighting(fsiRunner.consoleView, text, highlighter)
+        }
+
+        (fsiRunner.consoleView as LanguageConsoleImpl).flushDeferredText()
+
+        if (iconWithTooltip == null) return@runWriteCommandAction
+
+        fsiRunner.consoleView.historyViewer.markupModel.addRangeHighlighter(
+                startOffset, endOffset, HighlighterLayer.LAST, null, HighlighterTargetArea.LINES_IN_RANGE
+        ).apply { gutterIconRenderer = FsiConsoleIndicatorRenderer(iconWithTooltip) }
+    }
+
+    private fun printOutputInitialText(text: String, outputType: ConsoleViewContentType)  = WriteCommandAction.runWriteCommandAction(fsiRunner.project){
+        fsiRunner.consoleView.print(text, outputType)
+    }
+}

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiProcessHandler.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiProcessHandler.kt
@@ -34,6 +34,8 @@ class FsiProcessHandler (
         }
         else {
             sandboxInfoUpdaters.forEach { it.onOutputEnd() }
+
+            fsiInputOutputProcessor.onServerPrompt()
         }
     }
 

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiProcessHandler.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiProcessHandler.kt
@@ -1,27 +1,57 @@
 package com.jetbrains.rider.plugins.fsharp.services.fsi
 
 import com.intellij.execution.process.OSProcessHandler
+import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessOutputTypes
+import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.openapi.util.Key
-import java.nio.charset.Charset
 
 class FsiProcessHandler (
-        process: Process, commandLine: String?) : OSProcessHandler(process, commandLine, Charsets.UTF_8) {
+        private val fsiInputOutputProcessor: FsiInputOutputProcessor,
+        process: Process,
+        commandLine: String?) : OSProcessHandler(process, commandLine, Charsets.UTF_8) {
 
     private val sandboxInfoUpdaters = mutableListOf<FsiSandboxInfoUpdater>()
+    private val fsiProcessOutputListeners = mutableListOf<FsiSandboxInfoUpdater.FsiSandboxInfoUpdaterProcessOutputListener>()
 
     override fun isSilentlyDestroyOnClose(): Boolean = true
 
     override fun notifyTextAvailable(text: String, outputType: Key<*>) {
-        if (text != "SERVER-PROMPT>\n")
-            super.notifyTextAvailable(text, outputType)
-        else
-            sandboxInfoUpdaters.forEach{it.onOutputEnd()}
+        if (text != "SERVER-PROMPT>\n") {
+            when (outputType) {
+                ProcessOutputTypes.STDOUT -> {
+                    fsiInputOutputProcessor.printOutputText(text, ConsoleViewContentType.NORMAL_OUTPUT)
+                }
+                ProcessOutputTypes.STDERR -> {
+                    fsiInputOutputProcessor.printOutputText(text, ConsoleViewContentType.ERROR_OUTPUT)
+                }
+                else -> {
+                    super.notifyTextAvailable(text, outputType)
+                }
+            }
+
+            fsiProcessOutputListeners.forEach { it.onTextAvailable(ProcessEvent(this, text), outputType) }
+        }
+        else {
+            sandboxInfoUpdaters.forEach { it.onOutputEnd() }
+        }
+    }
+
+    override fun startNotify() {
+        super.startNotify()
+
+        fsiProcessOutputListeners.forEach { it.startNotified(ProcessEvent(this,  "")) }
+    }
+
+    override fun notifyProcessTerminated(exitCode: Int) {
+        super.notifyProcessTerminated(exitCode)
+
+        fsiProcessOutputListeners.forEach { it.processTerminated(ProcessEvent(this, "")) }
     }
 
     fun addSandboxInfoUpdater (sandboxInfoUpdater: FsiSandboxInfoUpdater) {
-        addProcessListener(sandboxInfoUpdater.fsiProcessOutputListener)
+        fsiProcessOutputListeners.add(sandboxInfoUpdater.fsiProcessOutputListener)
 
         sandboxInfoUpdaters.add(sandboxInfoUpdater)
     }
-
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/InputSeparatorGutterContentProvider.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/InputSeparatorGutterContentProvider.kt
@@ -17,4 +17,6 @@ class InputSeparatorGutterContentProvider(isLineRelationshipComputable: Boolean)
     fun addLineSeparator(line: Int) {
         separatorLines.add(line)
     }
+
+    override fun beforeEvaluate(editor: Editor) = Unit
 }


### PR DESCRIPTION
Add syntax highlighting and icons to separate input and output to history viewer.
![image](https://user-images.githubusercontent.com/26253351/83405325-f4b49d00-a414-11ea-9b70-7e36e79a229b.png)
