### PR TITLE
Reactor monitor improvements

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Common/FSharp.Common.fsproj
+++ b/ReSharper.FSharp/src/FSharp.Common/FSharp.Common.fsproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="src\FcsReactorMonitor.fs" />
     <Compile Include="src\Util\FSharpGlobalUtil.fs" />
     <Compile Include="src\Util\RegistryUtil.fs" />
     <Compile Include="src\Util\Util.fs" />

--- a/ReSharper.FSharp/src/FSharp.Common/FSharp.Common.fsproj
+++ b/ReSharper.FSharp/src/FSharp.Common/FSharp.Common.fsproj
@@ -14,7 +14,6 @@
     <Compile Include="src\Util\FSharpRangeUtil.fs" />
     <Compile Include="src\Util\FSharpCompilerAttributesUtil.fs" />
     <Compile Include="src\Util\FSharpAssemblyUtil.fs" />
-    <Compile Include="src\FcsReactorMonitor.fs" />
     <Compile Include="src\ProjectModel\FSharpLanguageVersion.fs" />
     <Compile Include="src\ProjectModel\FSharpProjectLanguage.fs" />
     <Compile Include="src\ProjectModel\ProjectProperties.fs" />
@@ -43,6 +42,7 @@
     <Compile Include="src\Checker\ScriptFcsProjectProvider.fs" />
     <Compile Include="src\Checker\FcsProjectBuilder.fs" />
     <Compile Include="src\Checker\FcsProjectProvider.fs" />
+    <Compile Include="src\FcsReactorMonitor.fs" />
     <Compile Include="src\PaketRestoreTargetsAnalyzer.fs" />
   </ItemGroup>
 

--- a/ReSharper.FSharp/src/FSharp.Common/FSharp.Common.fsproj
+++ b/ReSharper.FSharp/src/FSharp.Common/FSharp.Common.fsproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="src\FcsReactorMonitor.fs" />
     <Compile Include="src\Util\FSharpGlobalUtil.fs" />
     <Compile Include="src\Util\RegistryUtil.fs" />
     <Compile Include="src\Util\Util.fs" />
@@ -15,6 +14,7 @@
     <Compile Include="src\Util\FSharpRangeUtil.fs" />
     <Compile Include="src\Util\FSharpCompilerAttributesUtil.fs" />
     <Compile Include="src\Util\FSharpAssemblyUtil.fs" />
+    <Compile Include="src\FcsReactorMonitor.fs" />
     <Compile Include="src\ProjectModel\FSharpLanguageVersion.fs" />
     <Compile Include="src\ProjectModel\FSharpProjectLanguage.fs" />
     <Compile Include="src\ProjectModel\ProjectProperties.fs" />

--- a/ReSharper.FSharp/src/FSharp.Common/src/Checker/FSharpCheckerService.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/Checker/FSharpCheckerService.fs
@@ -28,8 +28,8 @@ module FSharpCheckerService =
 
 [<ShellComponent; AllowNullLiteral>]
 type FSharpCheckerService
-        (lifetime: Lifetime, logger: ILogger, onSolutionCloseNotifier: OnSolutionCloseNotifier,
-         settingsStore: ISettingsStore, settingsSchema: SettingsSchema) =
+        (lifetime, logger: ILogger, onSolutionCloseNotifier: OnSolutionCloseNotifier, settingsStore: ISettingsStore,
+         reactorMonitor: IFcsReactorMonitor, settingsSchema: SettingsSchema) =
 
     let checker =
         Environment.SetEnvironmentVariable("FCS_CheckFileInProjectCacheSize", "20")
@@ -97,6 +97,8 @@ type FSharpCheckerService
         let path = file.GetLocation().FullPath
         let source = FSharpCheckerService.getSourceText file.Document
         logger.Trace("ParseAndCheckFile: start {0}, {1}", path, opName)
+
+        let opName = reactorMonitor.RegisterOperation opName
 
         // todo: don't cancel the computation when file didn't change
         match x.Checker.ParseAndCheckDocument(path, source, options, allowStaleResults, opName).RunAsTask() with

--- a/ReSharper.FSharp/src/FSharp.Common/src/Checker/FSharpCheckerService.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/Checker/FSharpCheckerService.fs
@@ -140,7 +140,9 @@ type FSharpCheckerService
             let checkResults = results.CheckResults
             let fcsPos = getPosFromCoords coords
             let lineText = sourceFile.Document.GetLineText(coords.Line)
-            checkResults.GetSymbolUseAtLocation(fcsPos.Line, fcsPos.Column, lineText, names, opName).RunAsTask())
+
+            use op = x.FcsReactorMonitor.MonitorOperation opName
+            checkResults.GetSymbolUseAtLocation(fcsPos.Line, fcsPos.Column, lineText, names, op.OperationName).RunAsTask())
 
     /// Use with care: returns wrong symbol inside its non-recursive declaration, see dotnet/fsharp#7694.
     member x.ResolveNameAtLocation(sourceFile: IPsiSourceFile, name, coords, opName) =

--- a/ReSharper.FSharp/src/FSharp.Common/src/Checker/FSharpCheckerService.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/Checker/FSharpCheckerService.fs
@@ -28,8 +28,8 @@ module FSharpCheckerService =
 
 [<ShellComponent; AllowNullLiteral>]
 type FSharpCheckerService
-        (lifetime, logger: ILogger, onSolutionCloseNotifier: OnSolutionCloseNotifier, settingsStore: ISettingsStore,
-         settingsSchema: SettingsSchema) =
+        (lifetime: Lifetime, logger: ILogger, onSolutionCloseNotifier: OnSolutionCloseNotifier,
+         settingsStore: ISettingsStore, settingsSchema: SettingsSchema) =
 
     let checker =
         Environment.SetEnvironmentVariable("FCS_CheckFileInProjectCacheSize", "20")

--- a/ReSharper.FSharp/src/FSharp.Common/src/FcsReactorMonitor.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/FcsReactorMonitor.fs
@@ -33,12 +33,6 @@ module MonitoredReactorOperation =
 type IFcsReactorMonitor =
     abstract MonitorOperation : opName: string -> IMonitoredReactorOperation
 
-type private TrackedOperation =
-    {
-        StackTrace : StackTrace
-        OpName : string
-    }
-
 [<SolutionComponent>]
 type FcsReactorMonitor
         (lifetime: Lifetime, backgroundTaskHost: RiderBackgroundTaskHost, threading: IThreading,

--- a/ReSharper.FSharp/src/FSharp.Common/src/FcsReactorMonitor.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/FcsReactorMonitor.fs
@@ -1,25 +1,39 @@
-namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Features
+namespace JetBrains.ReSharper.Plugins.FSharp
 
 open System
+open System.Collections.Concurrent
 open System.Diagnostics
 open System.IO
 open System.Text.RegularExpressions
+open JetBrains.Application
 open JetBrains.Application.Environment
 open JetBrains.Application.Environment.Helpers
 open JetBrains.Application.Threading
 open JetBrains.DataFlow
+open JetBrains.Diagnostics
 open JetBrains.Lifetimes
 open JetBrains.ProjectModel
 open JetBrains.ReSharper.Host.Features.BackgroundTasks
+open JetBrains.Util
 
-[<SolutionComponent>]
+type private TrackedOperation =
+    {
+        StackTrace : StackTrace
+        OpName : string
+    }
+
+type IFcsReactorMonitor =
+    abstract RegisterOperation : opName: string -> string
+
+[<ShellComponent>]
 type FcsReactorMonitor
         (
             lifetime: Lifetime,
             locks: IShellLocks,
             backgroundTaskHost: RiderBackgroundTaskHost,
             threading: IThreading,
-            configurations: RunsProducts.ProductConfigurations
+            configurations: RunsProducts.ProductConfigurations,
+            logger: ILogger
         ) as this =
     inherit TraceListener("FcsReactorMonitor")
 
@@ -28,10 +42,16 @@ type FcsReactorMonitor
         if configurations.IsInternalMode() then 3.0 else 5.0
         |> TimeSpan.FromSeconds
 
+    let operations = ConcurrentDictionary<Guid, TrackedOperation>()
+
     /// How long after the reactor becoming free that the background task should be hidden
     let hideDelay = TimeSpan.FromSeconds 0.5
 
+    /// How long an operation must be running for before a stack trace of the enqueuing thread is dumped
+    let dumpStackDelay = TimeSpan.FromSeconds 0.1
+
     let isReactorBusy = new Property<bool>("isReactorBusy")
+    let currentTrackedOperation = new Property<TrackedOperation option>("currentTrackedOperation")
     let operationCount = new Property<int64>("operationCount")
 
     let taskHeader = new Property<string>("taskHeader")
@@ -60,11 +80,28 @@ type FcsReactorMonitor
             fun () -> backgroundTaskHost.AddNewTask(activeLifetime, task)
         )
 
-    let onOperationStart (opDescription: string) (opArg: string) =
+    let onOperationStart (opName: string) (opArg: string) =
         locks.Dispatcher.AssertAccess()
-
         operationCount.SetValue(operationCount.Value + 1L) |> ignore
-        taskHeader.SetValue opDescription |> ignore
+
+        // Try to parse a GUID from the front of the opName
+        let opName =
+            if opName.Length > 38 && opName.[0] = '{' then
+                match Guid.TryParse(opName.Substring(0, 38)) with
+                | false, _ -> opName
+                | true, opGuid ->
+
+                match operations.TryRemove opGuid with
+                | false, _ -> ()
+                | true, trackedOp ->
+                    // If we're tracking an operation with this GUID, set the current tracked operation
+                    currentTrackedOperation.SetValue(Some trackedOp) |> ignore
+
+                opName.Substring 38
+            else
+                opName
+
+        taskHeader.SetValue opName |> ignore
 
         let opArg = if Path.IsPathRooted opArg then Path.GetFileName opArg else opArg
         taskDescription.SetValue(sprintf "%s (operation #%d)" opArg operationCount.Value) |> ignore
@@ -74,6 +111,7 @@ type FcsReactorMonitor
     let onOperationEnd () =
         locks.Dispatcher.AssertAccess()
 
+        currentTrackedOperation.SetValue None |> ignore
         isReactorBusy.SetValue false |> ignore
 
     let onTrace (message: string) =
@@ -90,7 +128,18 @@ type FcsReactorMonitor
     do
         showBackgroundTask.WhenTrue(lifetime, Action<_> createNewTask)
 
-        isReactorBusy.WhenTrue(lifetime, fun _ -> showBackgroundTask.SetValue true |> ignore)
+        let sequence = SequentialLifetimes lifetime
+        currentTrackedOperation.Change.Advise(lifetime, fun (args: PropertyChangedEventArgs<TrackedOperation option>) ->
+            sequence.TerminateCurrent()
+
+            match args.New with
+            | None -> ()
+            | Some trackedOp ->
+
+            threading.QueueAt(sequence.Next(), "FcsReactorMonitor.DumpSlowOperation", dumpStackDelay, fun () ->
+                logger.Warn("Operation '{0}' is taking a long time. Stack trace of operation:\n{1}", trackedOp.OpName, trackedOp.StackTrace)))
+
+        isReactorBusy.WhenTrue(lifetime, fun lt -> showBackgroundTask.SetValue true |> ignore)
 
         isReactorBusy.WhenFalse(lifetime, fun lt ->
             threading.QueueAt(lt, "FcsReactorMonitor.HideTask", hideDelay, fun () ->
@@ -102,3 +151,14 @@ type FcsReactorMonitor
 
     override x.Write(_: string) = ()
     override x.WriteLine(message: string) = if message.StartsWith "Reactor:" then onTrace message
+
+    interface IFcsReactorMonitor with
+        override __.RegisterOperation opName =
+            // Only take stack traces when trace logging is enabled
+            if not (logger.IsEnabled LoggingLevel.TRACE) then opName else
+
+            let stackTrace = StackTrace(1, true)
+            let opGuid = Guid.NewGuid()
+            operations.TryAdd(opGuid, { StackTrace = stackTrace; OpName = opName }) |> ignore
+
+            (opGuid.ToString "B") + opName

--- a/ReSharper.FSharp/src/FSharp.Common/src/FcsReactorMonitor.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/FcsReactorMonitor.fs
@@ -56,8 +56,7 @@ type FcsReactorMonitor
     let hideDelay = TimeSpan.FromSeconds 0.5
 
     /// How long an operation must be running for before a stack trace of the enqueuing thread is dumped
-    /// TODO: change to 10.0 before merging!
-    let dumpStackDelay = TimeSpan.FromSeconds 1.0
+    let dumpStackDelay = TimeSpan.FromSeconds 10.0
 
     let mutable slowOperationTimer = null
     let isReactorBusy = new Property<bool>("isReactorBusy")

--- a/ReSharper.FSharp/src/FSharp.Common/src/FcsReactorMonitor.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/FcsReactorMonitor.fs
@@ -5,16 +5,33 @@ open System.Collections.Concurrent
 open System.Diagnostics
 open System.IO
 open System.Text.RegularExpressions
-open JetBrains.Application
+open System.Threading
 open JetBrains.Application.Environment
 open JetBrains.Application.Environment.Helpers
 open JetBrains.Application.Threading
 open JetBrains.DataFlow
 open JetBrains.Diagnostics
 open JetBrains.Lifetimes
+open JetBrains.Platform.RdFramework.Util
 open JetBrains.ProjectModel
 open JetBrains.ReSharper.Host.Features.BackgroundTasks
 open JetBrains.Util
+
+type IMonitoredReactorOperation =
+    inherit IDisposable
+    abstract OperationName : string
+
+[<RequireQualifiedAccess>]
+module MonitoredReactorOperation =
+    let empty opName =
+        { new IMonitoredReactorOperation with
+            override __.Dispose () = ()
+            override __.OperationName = opName
+        }
+
+
+type IFcsReactorMonitor =
+    abstract MonitorOperation : opName: string -> IMonitoredReactorOperation
 
 type private TrackedOperation =
     {
@@ -22,37 +39,28 @@ type private TrackedOperation =
         OpName : string
     }
 
-type IFcsReactorMonitor =
-    abstract RegisterOperation : opName: string -> string
-
-[<ShellComponent>]
+[<SolutionComponent>]
 type FcsReactorMonitor
-        (
-            lifetime: Lifetime,
-            locks: IShellLocks,
-            backgroundTaskHost: RiderBackgroundTaskHost,
-            threading: IThreading,
-            configurations: RunsProducts.ProductConfigurations,
-            logger: ILogger
-        ) as this =
+        (lifetime: Lifetime, backgroundTaskHost: RiderBackgroundTaskHost, threading: IThreading,
+         configurations: RunsProducts.ProductConfigurations, logger: ILogger, solution: ISolution) as this =
+
     inherit TraceListener("FcsReactorMonitor")
 
     /// How long after the reactor becoming busy that the background task should be shown
-    let showDelay =
-        if configurations.IsInternalMode() then 3.0 else 5.0
-        |> TimeSpan.FromSeconds
+    let showDelay = new Property<TimeSpan>("showDelay")
 
-    let operations = ConcurrentDictionary<Guid, TrackedOperation>()
+    let mutable lastOperationId = 0L
+    let operations = ConcurrentDictionary<int64, StackTrace>()
 
     /// How long after the reactor becoming free that the background task should be hidden
     let hideDelay = TimeSpan.FromSeconds 0.5
 
     /// How long an operation must be running for before a stack trace of the enqueuing thread is dumped
-    let dumpStackDelay = TimeSpan.FromSeconds 0.1
+    /// TODO: change to 10.0 before merging!
+    let dumpStackDelay = TimeSpan.FromSeconds 1.0
 
+    let mutable slowOperationTimer = null
     let isReactorBusy = new Property<bool>("isReactorBusy")
-    let currentTrackedOperation = new Property<TrackedOperation option>("currentTrackedOperation")
-    let operationCount = new Property<int64>("operationCount")
 
     let taskHeader = new Property<string>("taskHeader")
     let taskDescription = new Property<string>("taskDescription")
@@ -61,8 +69,6 @@ type FcsReactorMonitor
     let opStartRegex = Regex(@"--> (.+) \((.+)\), remaining \d+$", RegexOptions.Compiled)
 
     let createNewTask (activeLifetime: Lifetime) =
-        locks.Dispatcher.AssertAccess()
-
         let task =
             RiderBackgroundTaskBuilder.Create()
                 .WithTitle("F# Compiler Service is busy...")
@@ -76,68 +82,68 @@ type FcsReactorMonitor
         threading.QueueAt(
             activeLifetime,
             "FcsReactorMonitor.AddNewTask",
-            showDelay,
-            fun () -> backgroundTaskHost.AddNewTask(activeLifetime, task)
-        )
+            showDelay.Value,
+            fun () -> backgroundTaskHost.AddNewTask(activeLifetime, task))
 
+    /// Called when a FCS operation starts.
+    /// Always called from the current FCS reactor thread.
     let onOperationStart (opName: string) (opArg: string) =
-        locks.Dispatcher.AssertAccess()
-        operationCount.SetValue(operationCount.Value + 1L) |> ignore
+        // Try to parse the operation ID from the front of the opName
+        let operationId, opName =
+            let endIndex = opName.IndexOf '}'
+            if endIndex = -1 || opName.[0] <> '{' then None, opName else
 
-        // Try to parse a GUID from the front of the opName
-        let opName =
-            if opName.Length > 38 && opName.[0] = '{' then
-                match Guid.TryParse(opName.Substring(0, 38)) with
-                | false, _ -> opName
-                | true, opGuid ->
+            match Int64.TryParse(opName.Substring(1, endIndex - 1)) with
+            | false, _ -> None, opName
+            | true, operationId ->
 
-                match operations.TryRemove opGuid with
-                | false, _ -> ()
-                | true, trackedOp ->
-                    // If we're tracking an operation with this GUID, set the current tracked operation
-                    currentTrackedOperation.SetValue(Some trackedOp) |> ignore
+            let opName = opName.Substring(endIndex + 1)
 
-                opName.Substring 38
-            else
-                opName
+            match operations.TryGetValue operationId with
+            | null -> None, opName
+            | stackTrace ->
+
+            // Warn if the operation still hasn't finished in a few seconds
+            slowOperationTimer <-
+                let callback _ = logger.Warn("Operation '{0}' ({1}) is taking a long time. Stack trace:\n{2}", opName, opArg, stackTrace)
+                new Timer(callback, null, dumpStackDelay, Timeout.InfiniteTimeSpan)
+
+            Some operationId, opName
 
         taskHeader.SetValue opName |> ignore
 
         let opArg = if Path.IsPathRooted opArg then Path.GetFileName opArg else opArg
-        taskDescription.SetValue(sprintf "%s (operation #%d)" opArg operationCount.Value) |> ignore
+        match operationId with
+        | None -> taskDescription.SetValue(opArg) |> ignore
+        | Some operationId -> taskDescription.SetValue(sprintf "%s (operation #%d)" opArg operationId) |> ignore
 
         isReactorBusy.SetValue true |> ignore
 
+    /// Called when a FCS operation ends.
+    /// Always called from the current FCS reactor thread.
     let onOperationEnd () =
-        locks.Dispatcher.AssertAccess()
+        // Cancel slow operation timer - the operation is now finished
+        if isNotNull slowOperationTimer then
+            slowOperationTimer.Dispose()
+            slowOperationTimer <- null
 
-        currentTrackedOperation.SetValue None |> ignore
         isReactorBusy.SetValue false |> ignore
 
     let onTrace (message: string) =
         // todo: add and use a proper reactor event interface in FCS instead of matching trace messages
 
         if message.Contains "<--" then
-            locks.ExecuteOrQueue(lifetime, "FcsReactorMonitor.OnOperationEnd", onOperationEnd)
+            onOperationEnd ()
         else
             let opStartMatch = opStartRegex.Match(message)
             if opStartMatch.Success then
-                locks.ExecuteOrQueue(lifetime, "FcsReactorMonitor.OnOperationStart", fun () ->
-                    onOperationStart (opStartMatch.Groups.[1].Value) (opStartMatch.Groups.[2].Value))
+                onOperationStart (opStartMatch.Groups.[1].Value) (opStartMatch.Groups.[2].Value)
 
     do
+        solution.RdFSharpModel().FcsBusyDelayMs.FlowInto(lifetime, showDelay,
+            fun ms -> TimeSpan.FromMilliseconds(float ms))
+
         showBackgroundTask.WhenTrue(lifetime, Action<_> createNewTask)
-
-        let sequence = SequentialLifetimes lifetime
-        currentTrackedOperation.Change.Advise(lifetime, fun (args: PropertyChangedEventArgs<TrackedOperation option>) ->
-            sequence.TerminateCurrent()
-
-            match args.New with
-            | None -> ()
-            | Some trackedOp ->
-
-            threading.QueueAt(sequence.Next(), "FcsReactorMonitor.DumpSlowOperation", dumpStackDelay, fun () ->
-                logger.Warn("Operation '{0}' is taking a long time. Stack trace of operation:\n{1}", trackedOp.OpName, trackedOp.StackTrace)))
 
         isReactorBusy.WhenTrue(lifetime, fun lt -> showBackgroundTask.SetValue true |> ignore)
 
@@ -153,12 +159,17 @@ type FcsReactorMonitor
     override x.WriteLine(message: string) = if message.StartsWith "Reactor:" then onTrace message
 
     interface IFcsReactorMonitor with
-        override __.RegisterOperation opName =
-            // Only take stack traces when trace logging is enabled
-            if not (logger.IsEnabled LoggingLevel.TRACE) then opName else
+        override __.MonitorOperation opName =
+            // Only monitor operations when trace logging is enabled
+            if not (logger.IsEnabled LoggingLevel.TRACE) then
+                MonitoredReactorOperation.empty opName
+            else
 
             let stackTrace = StackTrace(1, true)
-            let opGuid = Guid.NewGuid()
-            operations.TryAdd(opGuid, { StackTrace = stackTrace; OpName = opName }) |> ignore
+            let operationId = Interlocked.Increment &lastOperationId
+            operations.TryAdd(operationId, stackTrace) |> ignore
 
-            (opGuid.ToString "B") + opName
+            { new IMonitoredReactorOperation with
+                override __.Dispose () = match operations.TryRemove operationId with _ -> ()
+                override __.OperationName = sprintf "{%d}%s" operationId opName
+            }

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/FSharp.Psi.Features.fsproj
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/FSharp.Psi.Features.fsproj
@@ -165,7 +165,6 @@
     <Compile Include="src\LanguageService\SandboxDocumentLanguageSupportFSharpScript.fs" />
     <Compile Include="src\LanguageService\FSharpLanguageSpecificCopyPasteBehavior.fs" />
     <Compile Include="src\FSharpTypingAssist.fs" />
-    <Compile Include="src\FcsReactorMonitor.fs" />
     <Compile Include="src\ZoneMarker.fs" />
   </ItemGroup>
 

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Stages/FSharpIdentifierTooltipProvider.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Stages/FSharpIdentifierTooltipProvider.fs
@@ -23,12 +23,12 @@ open JetBrains.Util
 let [<Literal>] RiderTooltipSeparator = "_RIDER_HORIZONTAL_LINE_TOOLTIP_SEPARATOR_"
 
 [<SolutionComponent>]
-type FSharpIdentifierTooltipProvider(lifetime, solution, presenter, xmlDocService: FSharpXmlDocService) =
+type FSharpIdentifierTooltipProvider(lifetime, solution, presenter, xmlDocService: FSharpXmlDocService, reactorMonitor) =
     inherit IdentifierTooltipProvider<FSharpLanguage>(lifetime, solution, presenter)
 
     let [<Literal>] opName = "FSharpIdentifierTooltipProvider"
 
-    static member GetFSharpToolTipText(userOpName: string, checkResults: FSharpCheckFileResults, token: FSharpIdentifierToken) =
+    static member GetFSharpToolTipText(reactorMonitor: IFcsReactorMonitor, userOpName: string, checkResults: FSharpCheckFileResults, token: FSharpIdentifierToken) =
         // todo: fix getting qualifiers
         let tokenNames = [token.Name]
 
@@ -37,8 +37,10 @@ type FSharpIdentifierTooltipProvider(lifetime, solution, presenter, xmlDocServic
         let lineText = sourceFile.Document.GetLineText(coords.Line)
         use cookie = CompilationContextCookie.GetOrCreate(sourceFile.GetPsiModule().GetContextFromModule())
 
+        use op = reactorMonitor.MonitorOperation userOpName
+
         // todo: provide tooltip for #r strings in fsx, should pass String tag
-        let getTooltip = checkResults.GetStructuredToolTipText(int coords.Line + 1, int coords.Column, lineText, tokenNames, FSharpTokenTag.Identifier, userOpName)
+        let getTooltip = checkResults.GetStructuredToolTipText(int coords.Line + 1, int coords.Column, lineText, tokenNames, FSharpTokenTag.Identifier, op.OperationName)
         getTooltip.RunAsTask()
 
     override x.GetTooltip(highlighter) =
@@ -67,7 +69,7 @@ type FSharpIdentifierTooltipProvider(lifetime, solution, presenter, xmlDocServic
         | Some results ->
 
         let result = List()
-        let (FSharpToolTipText layouts) = FSharpIdentifierTooltipProvider.GetFSharpToolTipText(opName, results.CheckResults, token)
+        let (FSharpToolTipText layouts) = FSharpIdentifierTooltipProvider.GetFSharpToolTipText(reactorMonitor, opName, results.CheckResults, token)
         
         layouts |> List.iter (function
             | FSharpStructuredToolTipElement.None

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Stages/FSharpIdentifierTooltipProvider.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Stages/FSharpIdentifierTooltipProvider.fs
@@ -23,12 +23,12 @@ open JetBrains.Util
 let [<Literal>] RiderTooltipSeparator = "_RIDER_HORIZONTAL_LINE_TOOLTIP_SEPARATOR_"
 
 [<SolutionComponent>]
-type FSharpIdentifierTooltipProvider(lifetime, solution, presenter, xmlDocService: FSharpXmlDocService, reactorMonitor) =
+type FSharpIdentifierTooltipProvider(lifetime, solution, presenter, xmlDocService: FSharpXmlDocService) =
     inherit IdentifierTooltipProvider<FSharpLanguage>(lifetime, solution, presenter)
 
     let [<Literal>] opName = "FSharpIdentifierTooltipProvider"
 
-    static member GetFSharpToolTipText(reactorMonitor: IFcsReactorMonitor, userOpName: string, checkResults: FSharpCheckFileResults, token: FSharpIdentifierToken) =
+    static member GetFSharpToolTipText(userOpName: string, checkResults: FSharpCheckFileResults, token: FSharpIdentifierToken) =
         // todo: fix getting qualifiers
         let tokenNames = [token.Name]
 
@@ -37,7 +37,7 @@ type FSharpIdentifierTooltipProvider(lifetime, solution, presenter, xmlDocServic
         let lineText = sourceFile.Document.GetLineText(coords.Line)
         use cookie = CompilationContextCookie.GetOrCreate(sourceFile.GetPsiModule().GetContextFromModule())
 
-        use op = reactorMonitor.MonitorOperation userOpName
+        use op = token.GetFcsCheckerService().FcsReactorMonitor.MonitorOperation userOpName
 
         // todo: provide tooltip for #r strings in fsx, should pass String tag
         let getTooltip = checkResults.GetStructuredToolTipText(int coords.Line + 1, int coords.Column, lineText, tokenNames, FSharpTokenTag.Identifier, op.OperationName)
@@ -69,7 +69,7 @@ type FSharpIdentifierTooltipProvider(lifetime, solution, presenter, xmlDocServic
         | Some results ->
 
         let result = List()
-        let (FSharpToolTipText layouts) = FSharpIdentifierTooltipProvider.GetFSharpToolTipText(reactorMonitor, opName, results.CheckResults, token)
+        let (FSharpToolTipText layouts) = FSharpIdentifierTooltipProvider.GetFSharpToolTipText(opName, results.CheckResults, token)
         
         layouts |> List.iter (function
             | FSharpStructuredToolTipElement.None

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Stages/PipeChainTypeHintStage.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Stages/PipeChainTypeHintStage.fs
@@ -59,7 +59,7 @@ type PipeOperatorVisitor(sameLinePipeHints: SameLinePipeHints) =
         visitBinaryAppExpr binaryAppExpr context
         x.VisitNode(binaryAppExpr, context)
 
-type PipeChainHighlightingProcess(logger: ILogger, fsFile, settings: IContextBoundSettingsStore, reactorMonitor, daemonProcess: IDaemonProcess) =
+type PipeChainHighlightingProcess(logger: ILogger, fsFile, settings: IContextBoundSettingsStore, daemonProcess: IDaemonProcess) =
     inherit FSharpDaemonStageProcessBase(fsFile, daemonProcess)
 
     let [<Literal>] opName = "PipeChainHighlightingProcess"
@@ -81,7 +81,7 @@ type PipeChainHighlightingProcess(logger: ILogger, fsFile, settings: IContextBou
         for token, exprToAdorn in exprs do
             if daemonProcess.InterruptFlag then raise <| OperationCanceledException()
 
-            let (FSharpToolTipText layouts) = FSharpIdentifierTooltipProvider.GetFSharpToolTipText(reactorMonitor, opName, checkResults, token)
+            let (FSharpToolTipText layouts) = FSharpIdentifierTooltipProvider.GetFSharpToolTipText(opName, checkResults, token)
 
             // The |> operator should have one overload and two type parameters
             match layouts with
@@ -138,7 +138,7 @@ type PipeChainHighlightingProcess(logger: ILogger, fsFile, settings: IContextBou
         committer.Invoke(DaemonStageResult remainingHighlightings)
 
 [<DaemonStage(StagesBefore = [| typeof<GlobalFileStructureCollectorStage> |])>]
-type PipeChainTypeHintStage(logger: ILogger, reactorMonitor: IFcsReactorMonitor) =
+type PipeChainTypeHintStage(logger: ILogger) =
     inherit FSharpDaemonStageBase()
 
     override x.IsSupported(sourceFile, processKind) =
@@ -148,4 +148,4 @@ type PipeChainTypeHintStage(logger: ILogger, reactorMonitor: IFcsReactorMonitor)
 
     override x.CreateStageProcess(fsFile, settings, daemonProcess) =
         if not (settings.GetValue(fun (key: FSharpTypeHintOptions) -> key.ShowPipeReturnTypes)) then null else
-        PipeChainHighlightingProcess(logger, fsFile, settings, reactorMonitor, daemonProcess) :> _
+        PipeChainHighlightingProcess(logger, fsFile, settings, daemonProcess) :> _

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Stages/PipeChainTypeHintStage.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Stages/PipeChainTypeHintStage.fs
@@ -59,7 +59,7 @@ type PipeOperatorVisitor(sameLinePipeHints: SameLinePipeHints) =
         visitBinaryAppExpr binaryAppExpr context
         x.VisitNode(binaryAppExpr, context)
 
-type PipeChainHighlightingProcess(logger: ILogger, fsFile, settings: IContextBoundSettingsStore, daemonProcess: IDaemonProcess) =
+type PipeChainHighlightingProcess(logger: ILogger, fsFile, settings: IContextBoundSettingsStore, reactorMonitor, daemonProcess: IDaemonProcess) =
     inherit FSharpDaemonStageProcessBase(fsFile, daemonProcess)
 
     let [<Literal>] opName = "PipeChainHighlightingProcess"
@@ -81,7 +81,7 @@ type PipeChainHighlightingProcess(logger: ILogger, fsFile, settings: IContextBou
         for token, exprToAdorn in exprs do
             if daemonProcess.InterruptFlag then raise <| OperationCanceledException()
 
-            let (FSharpToolTipText layouts) = FSharpIdentifierTooltipProvider.GetFSharpToolTipText(opName, checkResults, token)
+            let (FSharpToolTipText layouts) = FSharpIdentifierTooltipProvider.GetFSharpToolTipText(reactorMonitor, opName, checkResults, token)
 
             // The |> operator should have one overload and two type parameters
             match layouts with
@@ -138,7 +138,7 @@ type PipeChainHighlightingProcess(logger: ILogger, fsFile, settings: IContextBou
         committer.Invoke(DaemonStageResult remainingHighlightings)
 
 [<DaemonStage(StagesBefore = [| typeof<GlobalFileStructureCollectorStage> |])>]
-type PipeChainTypeHintStage(logger: ILogger) =
+type PipeChainTypeHintStage(logger: ILogger, reactorMonitor: IFcsReactorMonitor) =
     inherit FSharpDaemonStageBase()
 
     override x.IsSupported(sourceFile, processKind) =
@@ -148,4 +148,4 @@ type PipeChainTypeHintStage(logger: ILogger) =
 
     override x.CreateStageProcess(fsFile, settings, daemonProcess) =
         if not (settings.GetValue(fun (key: FSharpTypeHintOptions) -> key.ShowPipeReturnTypes)) then null else
-        PipeChainHighlightingProcess(logger, fsFile, settings, daemonProcess) :> _
+        PipeChainHighlightingProcess(logger, fsFile, settings, reactorMonitor, daemonProcess) :> _

--- a/ReSharper.FSharp/src/Services.FSharp/Services.FSharp.csproj
+++ b/ReSharper.FSharp/src/Services.FSharp/Services.FSharp.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net461</TargetFramework>
     <RootNamespace>JetBrains.ReSharper.Plugins.FSharp.Services.Cs</RootNamespace>
     <AssemblyName>JetBrains.ReSharper.Plugins.FSharp.Services.Cs</AssemblyName>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ReSharper.FSharp/src/Services.FSharp/src/ParameterInfo/FSharpParameterInfoContextFactory.cs
+++ b/ReSharper.FSharp/src/Services.FSharp/src/ParameterInfo/FSharpParameterInfoContextFactory.cs
@@ -50,8 +50,10 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Services.Cs.ParameterInfo
       var paramInfoLocations = paramInfoLocationsOption.Value;
       var names = paramInfoLocations.LongId;
       var lidEnd = paramInfoLocations.LongIdEndLocation;
+
+      using var op = fsFile.CheckerService.FcsReactorMonitor.MonitorOperation(OpName);
       var getMethodsAsync =
-        checkResults.GetMethods(lidEnd.Line, lidEnd.Column, string.Empty, OptionModule.OfObj(names), FSharpOption<string>.None);
+        checkResults.GetMethods(lidEnd.Line, lidEnd.Column, string.Empty, OptionModule.OfObj(names), FSharpOption<string>.Some(op.OperationName));
 
       // do not show when no overloads are found or got an operator info
       // github.com/Microsoft/visualfsharp/blob/Visual-Studio-2017/vsintegration/src/FSharp.LanguageService/Intellisense.fs#L274

--- a/ReSharper.FSharp/test/src/FSharp.Common.Tests/FSharp.Common.Tests.fsproj
+++ b/ReSharper.FSharp/test/src/FSharp.Common.Tests/FSharp.Common.Tests.fsproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ItemsContainerTest.fs" />
+    <Compile Include="Stubs.fs" />
     <Compile Include="ZoneMarker.fs" />
     <Compile Include="SciptPsiModulesTest.fs" />
   </ItemGroup>

--- a/ReSharper.FSharp/test/src/FSharp.Common.Tests/Stubs.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Common.Tests/Stubs.fs
@@ -1,0 +1,9 @@
+namespace JetBrains.ReSharper.Plugins.FSharp.Common.Tests.Stubs
+
+open JetBrains.Application.Components
+open JetBrains.ProjectModel
+open JetBrains.ReSharper.Plugins.FSharp
+
+[<SolutionComponent>]
+type TestFcsReactorMonitor() =
+    interface IHideImplementation<FcsReactorMonitor>

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Stubs.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Stubs.fs
@@ -3,9 +3,9 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Tests
 open JetBrains.Application
 open JetBrains.Application.Components
 open JetBrains.ProjectModel
+open JetBrains.ReSharper.Plugins.FSharp
 open JetBrains.ReSharper.Plugins.FSharp.ProjectModel
 open JetBrains.ReSharper.Plugins.FSharp.ProjectModel.Scripts
-open JetBrains.ReSharper.Plugins.FSharp.Psi.Features
 open JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Fsi
 
 [<SolutionComponent>]
@@ -23,3 +23,6 @@ type FSharpFileServiceStub() =
 [<SolutionComponent>]
 type TestFcsReactorMonitor() =
     interface IHideImplementation<FcsReactorMonitor>
+
+    interface IFcsReactorMonitor with
+        member x.MonitorOperation opName = MonitoredReactorOperation.empty opName

--- a/rider-fsharp/protocol/src/kotlin/model/RdFSharpModel.kt
+++ b/rider-fsharp/protocol/src/kotlin/model/RdFSharpModel.kt
@@ -53,5 +53,6 @@ object RdFSharpModel : Ext(SolutionModel.Solution) {
         field("fcsHost", RdFcsHost)
         property("enableExperimentalFeatures", bool)
         property("enableFormatter", bool)
+        property("fcsBusyDelayMs", int)
     }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/FSharpHost.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/FSharpHost.kt
@@ -15,19 +15,21 @@ class FSharpHost(project: Project) : LifetimedProjectComponent(project) {
     companion object {
         const val experimentalFeaturesRegistryKey = "rider.fsharp.experimental"
         const val formatterRegistryKey = "rider.fsharp.formatter"
+        const val fcsBusyDelayRegistryKey = "rider.fsharp.fcsBusyDelay.ms"
     }
 
     init {
-        initRegistryValue(experimentalFeaturesRegistryKey, fSharpModel.enableExperimentalFeatures)
-        initRegistryValue(formatterRegistryKey, fSharpModel.enableFormatter)
+        initRegistryValue(experimentalFeaturesRegistryKey, RegistryValue::asBoolean, fSharpModel.enableExperimentalFeatures)
+        initRegistryValue(formatterRegistryKey, RegistryValue::asBoolean, fSharpModel.enableFormatter)
+        initRegistryValue(fcsBusyDelayRegistryKey, RegistryValue::asInteger, fSharpModel.fcsBusyDelayMs)
     }
 
-    private fun initRegistryValue(registryKey: String, property: IOptProperty<Boolean>) {
+    private fun <T : Any> initRegistryValue(registryKey: String, registryToValue: (registryValue: RegistryValue) -> T, property: IOptProperty<T>) {
         val registryValue = Registry.get(registryKey)
-        property.set(registryValue.asBoolean())
+        property.set(registryToValue(registryValue))
         registryValue.addListener(object : RegistryValueListener.Adapter() {
             override fun afterValueChanged(value: RegistryValue) {
-                property.set(value.asBoolean())
+                property.set(registryToValue(value))
             }
         }, project)
     }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/logs/FSharpLogTraceScenarios.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/logs/FSharpLogTraceScenarios.kt
@@ -1,0 +1,9 @@
+package com.jetbrains.rider.plugins.fsharp.logs
+
+import com.jetbrains.rdclient.diagnostics.LogTraceScenario
+
+object FSharpLogTraceScenarios {
+    object FcsReactorMonitor : LogTraceScenario(
+            "JetBrains.ReSharper.Plugins.FSharp.FcsReactorMonitor"
+    )
+}

--- a/rider-fsharp/src/main/resources/META-INF/plugin.xml
+++ b/rider-fsharp/src/main/resources/META-INF/plugin.xml
@@ -28,7 +28,6 @@
     <rider.debuggerSupportPolicy language="F#" implementationClass="com.jetbrains.rider.debugger.RiderDebuggerSupportPolicy" />
     <lineIndentProvider implementation="com.jetbrains.rider.plugins.fsharp.actions.FSharpDummyLineIndentProvider"/>
 
-
     <fileType name="F# Script" language="F# Script" extensions="fsx;fsscript" implementationClass="com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpScriptFileType" />
     <lang.ast.factory language="F# Script" implementationClass="com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpScriptAstFactory" />
     <lang.parserDefinition language="F# Script" implementationClass="com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpScriptParserDefinition" />
@@ -85,6 +84,9 @@
 
     <registryKey key="rider.fsharp.experimental" description="Enable experimental F# features" defaultValue="false" restartRequired="false"/>
     <registryKey key="rider.fsharp.formatter" description="Enable F# code formatter" defaultValue="false" restartRequired="false"/>
+    <registryKey key="rider.fsharp.fcsBusyDelay.ms" description="Number of milliseconds that the FCS reactor must be busy for before showing a background task" defaultValue="5000" restartRequired="false"/>
+
+    <rdclient.traceScenarioHolder implementation="com.jetbrains.rider.plugins.fsharp.logs.FSharpLogTraceScenarios"/>
   </extensions>
 
   <actions>


### PR DESCRIPTION
Changes:

- Added registry setting for delay: `rider.fsharp.fcsBusyDelay.ms` (defaults to 5 seconds)
- `onOperationStart` and `onOperationEnd` no longer have to be ran on the main thread
- Added "FcsReactorMonitor" to trace scenarios window. When enabled, slow FSC reactor operations will dump a stack trace of the enqueuing thread (default to 10 seconds)