### PR TITLE
Type abbreviations (aliases) highlighting

### DIFF
--- a/ReSharper.FSharp/src/Daemon.FSharp/src/FSharpSymbolHighlightingUtil.cs
+++ b/ReSharper.FSharp/src/Daemon.FSharp/src/FSharpSymbolHighlightingUtil.cs
@@ -2,8 +2,6 @@
 using JetBrains.Annotations;
 using JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.Highlightings;
 using JetBrains.ReSharper.Plugins.FSharp.Util;
-using JetBrains.Rider.Model.DebuggerWorker;
-using Microsoft.FSharp.Collections;
 using static FSharp.Compiler.PrettyNaming;
 
 namespace JetBrains.ReSharper.Plugins.FSharp.Daemon.Cs

--- a/ReSharper.FSharp/src/Daemon.FSharp/src/FSharpSymbolHighlightingUtil.cs
+++ b/ReSharper.FSharp/src/Daemon.FSharp/src/FSharpSymbolHighlightingUtil.cs
@@ -90,7 +90,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Daemon.Cs
 
       return FSharpHighlightingAttributeIdsModule.Value;
     }
-    
+
     [NotNull]
     public static string GetHighlightingAttributeId([NotNull] this FSharpSymbol symbol)
     {

--- a/ReSharper.FSharp/src/Daemon.FSharp/src/FSharpSymbolHighlightingUtil.cs
+++ b/ReSharper.FSharp/src/Daemon.FSharp/src/FSharpSymbolHighlightingUtil.cs
@@ -96,7 +96,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Daemon.Cs
       switch (symbol)
       {
         case FSharpEntity entity when !entity.IsUnresolved:
-          return GetEntityHighlightingAttributeId(entity.GetBaseTypeEntity());
+          return GetEntityHighlightingAttributeId(entity.GetAbbreviatedType());
 
         case FSharpMemberOrFunctionOrValue mfv when !mfv.IsUnresolved:
           return GetMfvHighlightingAttributeId(mfv.AccessorProperty?.Value ?? mfv);

--- a/ReSharper.FSharp/src/Daemon.FSharp/src/FSharpSymbolHighlightingUtil.cs
+++ b/ReSharper.FSharp/src/Daemon.FSharp/src/FSharpSymbolHighlightingUtil.cs
@@ -2,6 +2,8 @@
 using JetBrains.Annotations;
 using JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.Highlightings;
 using JetBrains.ReSharper.Plugins.FSharp.Util;
+using JetBrains.Rider.Model.DebuggerWorker;
+using Microsoft.FSharp.Collections;
 using static FSharp.Compiler.PrettyNaming;
 
 namespace JetBrains.ReSharper.Plugins.FSharp.Daemon.Cs
@@ -18,9 +20,6 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Daemon.Cs
       if (entity.IsEnum)
         return FSharpHighlightingAttributeIdsModule.Enum;
 
-      if (entity.IsValueType)
-        return FSharpHighlightingAttributeIdsModule.Struct;
-
       if (entity.IsDelegate)
         return FSharpHighlightingAttributeIdsModule.Delegate;
 
@@ -35,10 +34,14 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Daemon.Cs
 
       if (entity.IsMeasure)
         return FSharpHighlightingAttributeIdsModule.UnitOfMeasure;
+
+      if (entity.IsInterface)
+        return FSharpHighlightingAttributeIdsModule.Interface;
+
+      if (entity.IsValueType || entity.HasMeasureParameter())
+        return FSharpHighlightingAttributeIdsModule.Struct;
       
-      return entity.IsInterface
-        ? FSharpHighlightingAttributeIdsModule.Interface
-        : FSharpHighlightingAttributeIdsModule.Class;
+      return FSharpHighlightingAttributeIdsModule.Class;
     }
 
     [NotNull]
@@ -86,14 +89,14 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Daemon.Cs
 
       return FSharpHighlightingAttributeIdsModule.Value;
     }
-
+    
     [NotNull]
     public static string GetHighlightingAttributeId([NotNull] this FSharpSymbol symbol)
     {
       switch (symbol)
       {
         case FSharpEntity entity when !entity.IsUnresolved:
-          return GetEntityHighlightingAttributeId(entity);
+          return GetEntityHighlightingAttributeId(entity.GetBaseTypeEntity());
 
         case FSharpMemberOrFunctionOrValue mfv when !mfv.IsUnresolved:
           return GetMfvHighlightingAttributeId(mfv.AccessorProperty?.Value ?? mfv);

--- a/ReSharper.FSharp/src/Daemon.FSharp/src/FSharpSymbolHighlightingUtil.cs
+++ b/ReSharper.FSharp/src/Daemon.FSharp/src/FSharpSymbolHighlightingUtil.cs
@@ -36,6 +36,9 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Daemon.Cs
       if (entity.IsInterface)
         return FSharpHighlightingAttributeIdsModule.Interface;
 
+      if (entity.IsClass)
+        return FSharpHighlightingAttributeIdsModule.Class;
+      
       if (entity.IsValueType || entity.HasMeasureParameter())
         return FSharpHighlightingAttributeIdsModule.Struct;
       

--- a/ReSharper.FSharp/src/FSharp.Common/src/Util/FSharpSymbolUtil.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/Util/FSharpSymbolUtil.fs
@@ -146,5 +146,16 @@ let patternName (pattern: FSharpActivePatternGroup) =
     let wildCase = if pattern.IsTotal then "|" else "_|"
     "|" + joinedNames + wildCase
 
+[<Extension; CompiledName("GetBaseTypeEntity")>]
+let getBaseTypeEntity (entity: FSharpEntity) =
+    let mutable baseEntity = entity
+    while baseEntity.IsFSharpAbbreviation do
+        baseEntity <- baseEntity.AbbreviatedType.TypeDefinition
+    baseEntity
+
+[<Extension; CompiledName("HasMeasureParameter")>]
+let hasMeasureParameter(entity: FSharpEntity) =
+    entity.GenericParameters.Count > 0 && entity.GenericParameters.[0].IsMeasure;
+
 type FSharpActivePatternGroup with
     member x.PatternName = patternName x

--- a/ReSharper.FSharp/src/FSharp.Common/src/Util/FSharpSymbolUtil.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/Util/FSharpSymbolUtil.fs
@@ -145,13 +145,13 @@ let patternName (pattern: FSharpActivePatternGroup) =
     let joinedNames = String.concat "|" pattern.Names
     let wildCase = if pattern.IsTotal then "|" else "_|"
     "|" + joinedNames + wildCase
-
+    
 [<Extension; CompiledName("GetBaseTypeEntity")>]
 let getBaseTypeEntity (entity: FSharpEntity) =
-    let mutable baseEntity = entity
-    while baseEntity.IsFSharpAbbreviation do
-        baseEntity <- baseEntity.AbbreviatedType.TypeDefinition
-    baseEntity
+    let mutable baseTypeEntity = entity
+    while baseTypeEntity.IsFSharpAbbreviation && baseTypeEntity.AbbreviatedType.HasTypeDefinition do
+        baseTypeEntity <- baseTypeEntity.AbbreviatedType.TypeDefinition
+    baseTypeEntity
 
 [<Extension; CompiledName("HasMeasureParameter")>]
 let hasMeasureParameter(entity: FSharpEntity) =

--- a/ReSharper.FSharp/src/FSharp.Common/src/Util/FSharpSymbolUtil.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/Util/FSharpSymbolUtil.fs
@@ -146,8 +146,8 @@ let patternName (pattern: FSharpActivePatternGroup) =
     let wildCase = if pattern.IsTotal then "|" else "_|"
     "|" + joinedNames + wildCase
     
-[<Extension; CompiledName("GetBaseTypeEntity")>]
-let getBaseTypeEntity (entity: FSharpEntity) =
+[<Extension; CompiledName("GetAbbreviatedType")>]
+let getAbbreviatedType (entity: FSharpEntity) =
     let mutable baseTypeEntity = entity
     while baseTypeEntity.IsFSharpAbbreviation && baseTypeEntity.AbbreviatedType.HasTypeDefinition do
         baseTypeEntity <- baseTypeEntity.AbbreviatedType.TypeDefinition

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Byrefs 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Byrefs 01.fs.gold
@@ -11,7 +11,7 @@ let |hello|(1) (|name|(2): |byref|(3)<|string|(4)>) (|other|(5): |inref|(6)<|int
 (4): ReSharper F# Class Identifier: 
 (5): ReSharper F# Mutable Value Identifier: 
 (6): ReSharper F# Class Identifier: 
-(7): ReSharper F# Class Identifier: 
+(7): ReSharper F# Struct Identifier: 
 (8): ReSharper F# Mutable Value Identifier: 
 (9): ReSharper F# Class Identifier: 
-(10): ReSharper F# Class Identifier: 
+(10): ReSharper F# Struct Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates.fs.gold
@@ -9,5 +9,5 @@ type |T2|(4) = delegate of |int|(5) -> |int|(6)
 (2): ReSharper F# Class Identifier: 
 (3): ReSharper F# Class Identifier: 
 (4): ReSharper F# Delegate Identifier: 
-(5): ReSharper F# Class Identifier: 
-(6): ReSharper F# Class Identifier: 
+(5): ReSharper F# Struct Identifier: 
+(6): ReSharper F# Struct Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 01 - Simple types with System dependence.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 01 - Simple types with System dependence.fs
@@ -1,0 +1,10 @@
+open System
+
+type SimpleRecord = { Value : int }
+type SimpleDU = Value of int | Value2 of int * int
+
+type DUDummy = SimpleDU
+type RecordDummy = SimpleRecord
+type StructDummy = Int32
+type InterfaceDummy = IDisposable
+type ObjectDummy = Object

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 01 - Simple types with System dependence.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 01 - Simple types with System dependence.fs
@@ -1,7 +1,7 @@
 open System
 
 type SimpleRecord = { Value : int }
-type SimpleDU = Value of int | Value2 of int * int
+type SimpleDU = Value of int
 
 type DUDummy = SimpleDU
 type RecordDummy = SimpleRecord

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 01 - Simple types with System dependence.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 01 - Simple types with System dependence.fs.gold
@@ -1,13 +1,14 @@
 ﻿open |System|(0)
 
 type |SimpleRecord|(1) = { |Value|(2) : |int|(3) }
-type |SimpleDU|(4) = |Value|(5) of |int|(6) | |Value2|(7) of |int|(8) * |int|(9)
+type |SimpleDU|(4) = |Value|(5) of |int|(6)
 
-type |DUDummy|(10) = |SimpleDU|(11)
-type |RecordDummy|(12) = |SimpleRecord|(13)
-type |StructDummy|(14) = |Int32|(15)
-type |InterfaceDummy|(16) = |IDisposable|(17)
-type |ObjectDummy|(18) = |Object|(19)
+type |DUDummy|(7) = |SimpleDU|(8)
+type |RecordDummy|(9) = |SimpleRecord|(10)
+type |StructDummy|(11) = |Int32|(12)
+type |InterfaceDummy|(13) = |IDisposable|(14)
+type |ObjectDummy|(15) = |Object|(16)
+
 ---------------------------------------------------------
 (0): ReSharper F# Namespace Identifier: 
 (1): ReSharper F# Record Identifier: 
@@ -16,16 +17,13 @@ type |ObjectDummy|(18) = |Object|(19)
 (4): ReSharper F# Union Identifier: 
 (5): ReSharper F# Union Case Identifier: 
 (6): ReSharper F# Struct Identifier: 
-(7): ReSharper F# Union Case Identifier: 
-(8): ReSharper F# Struct Identifier: 
-(9): ReSharper F# Struct Identifier: 
-(10): ReSharper F# Union Identifier: 
-(11): ReSharper F# Union Identifier: 
-(12): ReSharper F# Record Identifier: 
-(13): ReSharper F# Record Identifier: 
-(14): ReSharper F# Struct Identifier: 
-(15): ReSharper F# Struct Identifier: 
-(16): ReSharper F# Interface Identifier: 
-(17): ReSharper F# Interface Identifier: 
-(18): ReSharper F# Class Identifier: 
-(19): ReSharper F# Class Identifier: 
+(7): ReSharper F# Union Identifier: 
+(8): ReSharper F# Union Identifier: 
+(9): ReSharper F# Record Identifier: 
+(10): ReSharper F# Record Identifier: 
+(11): ReSharper F# Struct Identifier: 
+(12): ReSharper F# Struct Identifier: 
+(13): ReSharper F# Interface Identifier: 
+(14): ReSharper F# Interface Identifier: 
+(15): ReSharper F# Class Identifier: 
+(16): ReSharper F# Class Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 01 - Simple types with System dependence.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 01 - Simple types with System dependence.fs.gold
@@ -1,0 +1,31 @@
+﻿open |System|(0)
+
+type |SimpleRecord|(1) = { |Value|(2) : |int|(3) }
+type |SimpleDU|(4) = |Value|(5) of |int|(6) | |Value2|(7) of |int|(8) * |int|(9)
+
+type |DUDummy|(10) = |SimpleDU|(11)
+type |RecordDummy|(12) = |SimpleRecord|(13)
+type |StructDummy|(14) = |Int32|(15)
+type |InterfaceDummy|(16) = |IDisposable|(17)
+type |ObjectDummy|(18) = |Object|(19)
+---------------------------------------------------------
+(0): ReSharper F# Namespace Identifier: 
+(1): ReSharper F# Record Identifier: 
+(2): ReSharper F# Field Identifier: 
+(3): ReSharper F# Struct Identifier: 
+(4): ReSharper F# Union Identifier: 
+(5): ReSharper F# Union Case Identifier: 
+(6): ReSharper F# Struct Identifier: 
+(7): ReSharper F# Union Case Identifier: 
+(8): ReSharper F# Struct Identifier: 
+(9): ReSharper F# Struct Identifier: 
+(10): ReSharper F# Union Identifier: 
+(11): ReSharper F# Union Identifier: 
+(12): ReSharper F# Record Identifier: 
+(13): ReSharper F# Record Identifier: 
+(14): ReSharper F# Struct Identifier: 
+(15): ReSharper F# Struct Identifier: 
+(16): ReSharper F# Interface Identifier: 
+(17): ReSharper F# Interface Identifier: 
+(18): ReSharper F# Class Identifier: 
+(19): ReSharper F# Class Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 02 - Simple types without System dependence.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 02 - Simple types without System dependence.fs
@@ -1,5 +1,5 @@
 type SimpleRecord = { Value : int }
-type SimpleDU = Value of int | Value2 of int * int
+type SimpleDU = Value of int
 
 type DUDummy = SimpleDU
 type RecordDummy = SimpleRecord

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 02 - Simple types without System dependence.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 02 - Simple types without System dependence.fs
@@ -1,0 +1,8 @@
+type SimpleRecord = { Value : int }
+type SimpleDU = Value of int | Value2 of int * int
+
+type DUDummy = SimpleDU
+type RecordDummy = SimpleRecord
+type StructDummy = Int32
+type InterfaceDummy = IDisposable
+type ObjectDummy = Object

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 02 - Simple types without System dependence.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 02 - Simple types without System dependence.fs.gold
@@ -1,0 +1,28 @@
+﻿type |SimpleRecord|(0) = { |Value|(1) : |int|(2) }
+type |SimpleDU|(3) = |Value|(4) of |int|(5) | |Value2|(6) of |int|(7) * |int|(8)
+
+type |DUDummy|(9) = |SimpleDU|(10)
+type |RecordDummy|(11) = |SimpleRecord|(12)
+type |StructDummy|(13) = |Int32|(14)
+type |InterfaceDummy|(15) = |IDisposable|(16)
+type |ObjectDummy|(17) = |Object|(18)
+---------------------------------------------------------
+(0): ReSharper F# Record Identifier: 
+(1): ReSharper F# Field Identifier: 
+(2): ReSharper F# Struct Identifier: 
+(3): ReSharper F# Union Identifier: 
+(4): ReSharper F# Union Case Identifier: 
+(5): ReSharper F# Struct Identifier: 
+(6): ReSharper F# Union Case Identifier: 
+(7): ReSharper F# Struct Identifier: 
+(8): ReSharper F# Struct Identifier: 
+(9): ReSharper F# Union Identifier: 
+(10): ReSharper F# Union Identifier: 
+(11): ReSharper F# Record Identifier: 
+(12): ReSharper F# Record Identifier: 
+(13): ReSharper F# Union Identifier: 
+(14): ReSharper F# Union Case Identifier: 
+(15): ReSharper F# Union Identifier: 
+(16): ReSharper F# Union Case Identifier: 
+(17): ReSharper F# Union Identifier: 
+(18): ReSharper F# Union Case Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 02 - Simple types without System dependence.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 02 - Simple types without System dependence.fs.gold
@@ -1,11 +1,12 @@
 ﻿type |SimpleRecord|(0) = { |Value|(1) : |int|(2) }
-type |SimpleDU|(3) = |Value|(4) of |int|(5) | |Value2|(6) of |int|(7) * |int|(8)
+type |SimpleDU|(3) = |Value|(4) of |int|(5)
 
-type |DUDummy|(9) = |SimpleDU|(10)
-type |RecordDummy|(11) = |SimpleRecord|(12)
-type |StructDummy|(13) = |Int32|(14)
-type |InterfaceDummy|(15) = |IDisposable|(16)
-type |ObjectDummy|(17) = |Object|(18)
+type |DUDummy|(6) = |SimpleDU|(7)
+type |RecordDummy|(8) = |SimpleRecord|(9)
+type |StructDummy|(10) = |Int32|(11)
+type |InterfaceDummy|(12) = |IDisposable|(13)
+type |ObjectDummy|(14) = |Object|(15)
+
 ---------------------------------------------------------
 (0): ReSharper F# Record Identifier: 
 (1): ReSharper F# Field Identifier: 
@@ -13,16 +14,13 @@ type |ObjectDummy|(17) = |Object|(18)
 (3): ReSharper F# Union Identifier: 
 (4): ReSharper F# Union Case Identifier: 
 (5): ReSharper F# Struct Identifier: 
-(6): ReSharper F# Union Case Identifier: 
-(7): ReSharper F# Struct Identifier: 
-(8): ReSharper F# Struct Identifier: 
-(9): ReSharper F# Union Identifier: 
+(6): ReSharper F# Union Identifier: 
+(7): ReSharper F# Union Identifier: 
+(8): ReSharper F# Record Identifier: 
+(9): ReSharper F# Record Identifier: 
 (10): ReSharper F# Union Identifier: 
-(11): ReSharper F# Record Identifier: 
-(12): ReSharper F# Record Identifier: 
-(13): ReSharper F# Union Identifier: 
-(14): ReSharper F# Union Case Identifier: 
-(15): ReSharper F# Union Identifier: 
-(16): ReSharper F# Union Case Identifier: 
-(17): ReSharper F# Union Identifier: 
-(18): ReSharper F# Union Case Identifier: 
+(11): ReSharper F# Union Case Identifier: 
+(12): ReSharper F# Union Identifier: 
+(13): ReSharper F# Union Case Identifier: 
+(14): ReSharper F# Union Identifier: 
+(15): ReSharper F# Union Case Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 03 - Units of measure.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 03 - Units of measure.fs
@@ -1,14 +1,7 @@
 [<Measure>] type m
 
-type MeasureRecord<[<Measure>] 'u> = { x : float<'u> }
-let mrec : MeasureRecord<m> = { x = 0.0<m>; }
+type IntMeasure = int<m>
 
-type MeasureDiscriminatedUnion<[<Measure>] 'a> = | IntMeasureMember of decimal<'a>
-let mdu = MeasureDiscriminatedUnion<m>.IntMeasureMember 10m<m>
-
-type MeasureClass<[<Measure>] 'a>() = class end    
+type MeasureClass<[<Measure>] 'a>() = class end
+let mclsctor = MeasureClass<m>
 let mcls = MeasureClass<m>()
-
-[<Struct>]
-type MeasureStruct<[<Measure>] 'a>(__ : int<'a>) = struct end
-let mstr = MeasureStruct<m>()

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 03 - Units of measure.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 03 - Units of measure.fs
@@ -1,0 +1,21 @@
+[<Measure>] type m
+[<Measure>] type s
+
+type MeasureBasicType = int<m/s>
+
+type MeasureRecord<[<Measure>] 'u> = { x : float<'u>; y : float<'u>; z : float<'u> }
+let mrec : MeasureRecord<m> = { x = 0.0<m>; y = 0.0<m>; z = 0.0<m> }
+
+type MeasureDiscriminatedUnion<[<Measure>] 'a> =
+    | IntMeasureMember of int<'a>
+    | FloatMeasureMember of float<'a>
+let mdu = MeasureDiscriminatedUnion<s>.IntMeasureMember 10<s>
+
+type MeasureClass<[<Measure>] 'a>(value : int<'a>) =
+    member x.Value = value
+let mcls = MeasureClass<s> 10<s>
+
+[<Struct>]
+type MeasureStruct<[<Measure>] 'a>(value : int<'a>) =
+    member x.Value = value    
+let mstr = MeasureStruct<s> 10<s>

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 03 - Units of measure.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 03 - Units of measure.fs
@@ -3,5 +3,5 @@
 type IntMeasure = int<m>
 
 type MeasureClass<[<Measure>] 'a>() = class end
-let mclsctor = MeasureClass<m>
-let mcls = MeasureClass<m>()
+
+let _: MeasureClass<m> = MeasureClass<m>()

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 03 - Units of measure.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 03 - Units of measure.fs
@@ -1,21 +1,14 @@
 [<Measure>] type m
-[<Measure>] type s
 
-type MeasureBasicType = int<m/s>
+type MeasureRecord<[<Measure>] 'u> = { x : float<'u> }
+let mrec : MeasureRecord<m> = { x = 0.0<m>; }
 
-type MeasureRecord<[<Measure>] 'u> = { x : float<'u>; y : float<'u>; z : float<'u> }
-let mrec : MeasureRecord<m> = { x = 0.0<m>; y = 0.0<m>; z = 0.0<m> }
+type MeasureDiscriminatedUnion<[<Measure>] 'a> = | IntMeasureMember of decimal<'a>
+let mdu = MeasureDiscriminatedUnion<m>.IntMeasureMember 10m<m>
 
-type MeasureDiscriminatedUnion<[<Measure>] 'a> =
-    | IntMeasureMember of int<'a>
-    | FloatMeasureMember of float<'a>
-let mdu = MeasureDiscriminatedUnion<s>.IntMeasureMember 10<s>
-
-type MeasureClass<[<Measure>] 'a>(value : int<'a>) =
-    member x.Value = value
-let mcls = MeasureClass<s> 10<s>
+type MeasureClass<[<Measure>] 'a>() = class end    
+let mcls = MeasureClass<m>()
 
 [<Struct>]
-type MeasureStruct<[<Measure>] 'a>(value : int<'a>) =
-    member x.Value = value    
-let mstr = MeasureStruct<s> 10<s>
+type MeasureStruct<[<Measure>] 'a>(__ : int<'a>) = struct end
+let mstr = MeasureStruct<m>()

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 03 - Units of measure.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 03 - Units of measure.fs.gold
@@ -1,92 +1,55 @@
 ﻿[<|Measure|(0)>] type |m|(1)
-[<|Measure|(2)>] type |s|(3)
 
-type |MeasureBasicType|(4) = |int|(5)<|m|(6)/|s|(7)>
+type |MeasureRecord|(2)<[<|Measure|(3)>] |'u|(4)> = { |x|(5) : |float|(6)<|'u|(7)> }
+let |mrec|(8) : |MeasureRecord|(9)<|m|(10)> = { |x|(11) = 0.0<|m|(12)>; }
 
-type |MeasureRecord|(8)<[<|Measure|(9)>] |'u|(10)> = { |x|(11) : |float|(12)<|'u|(13)>; |y|(14) : |float|(15)<|'u|(16)>; |z|(17) : |float|(18)<|'u|(19)> }
-let |mrec|(20) : |MeasureRecord|(21)<|m|(22)> = { |x|(23) = 0.0<|m|(24)>; |y|(25) = 0.0<|m|(26)>; |z|(27) = 0.0<|m|(28)> }
+type |MeasureDiscriminatedUnion|(13)<[<|Measure|(14)>] |'a|(15)> = | |IntMeasureMember|(16) of |decimal|(17)<|'a|(18)>
+let |mdu|(19) = |MeasureDiscriminatedUnion|(20)<|m|(21)>.|IntMeasureMember|(22) 10m<|m|(23)>
 
-type |MeasureDiscriminatedUnion|(29)<[<|Measure|(30)>] |'a|(31)> =
-    | |IntMeasureMember|(32) of |int|(33)<|'a|(34)>
-    | |FloatMeasureMember|(35) of |float|(36)<|'a|(37)>
-let |mdu|(38) = |MeasureDiscriminatedUnion|(39)<|s|(40)>.|IntMeasureMember|(41) 10<|s|(42)>
+type |MeasureClass|(24)<[<|Measure|(25)>] |'a|(26)>() = class end    
+let |mcls|(27) = |MeasureClass|(28)<|m|(29)>()
 
-type |MeasureClass|(43)<[<|Measure|(44)>] |'a|(45)>(|value|(46) : |int|(47)<|'a|(48)>) =
-    member |x|(49).|Value|(50) = |value|(51)
-let |mcls|(52) = |MeasureClass|(53)<|s|(54)> 10<|s|(55)>
-
-[<|Struct|(56)>]
-type |MeasureStruct|(57)<[<|Measure|(58)>] |'a|(59)>(|value|(60) : |int|(61)<|'a|(62)>) =
-    member |x|(63).|Value|(64) = |value|(65)    
-let |mstr|(66) = |MeasureStruct|(67)<|s|(68)> 10<|s|(69)>
+[<|Struct|(30)>]
+type |MeasureStruct|(31)<[<|Measure|(32)>] |'a|(33)>(|__|(34) : |int|(35)<|'a|(36)>) = struct end
+let |mstr|(37) = |MeasureStruct|(38)<|m|(39)>()
 ---------------------------------------------------------
 (0): ReSharper F# Class Identifier: 
 (1): ReSharper F# Unit Of Measure Identifier: 
-(2): ReSharper F# Class Identifier: 
-(3): ReSharper F# Unit Of Measure Identifier: 
-(4): ReSharper F# Struct Identifier: 
-(5): ReSharper F# Struct Identifier: 
-(6): ReSharper F# Unit Of Measure Identifier: 
-(7): ReSharper F# Unit Of Measure Identifier: 
-(8): ReSharper F# Record Identifier: 
-(9): ReSharper F# Class Identifier: 
-(10): ReSharper F# Type Parameter Identifier: 
+(2): ReSharper F# Record Identifier: 
+(3): ReSharper F# Class Identifier: 
+(4): ReSharper F# Type Parameter Identifier: 
+(5): ReSharper F# Field Identifier: 
+(6): ReSharper F# Struct Identifier: 
+(7): ReSharper F# Type Parameter Identifier: 
+(8): ReSharper F# Value Identifier: 
+(9): ReSharper F# Record Identifier: 
+(10): ReSharper F# Unit Of Measure Identifier: 
 (11): ReSharper F# Field Identifier: 
-(12): ReSharper F# Struct Identifier: 
-(13): ReSharper F# Type Parameter Identifier: 
-(14): ReSharper F# Field Identifier: 
-(15): ReSharper F# Struct Identifier: 
-(16): ReSharper F# Type Parameter Identifier: 
-(17): ReSharper F# Field Identifier: 
-(18): ReSharper F# Struct Identifier: 
-(19): ReSharper F# Type Parameter Identifier: 
-(20): ReSharper F# Value Identifier: 
-(21): ReSharper F# Record Identifier: 
-(22): ReSharper F# Unit Of Measure Identifier: 
-(23): ReSharper F# Field Identifier: 
-(24): ReSharper F# Unit Of Measure Identifier: 
-(25): ReSharper F# Field Identifier: 
-(26): ReSharper F# Unit Of Measure Identifier: 
-(27): ReSharper F# Field Identifier: 
-(28): ReSharper F# Unit Of Measure Identifier: 
-(29): ReSharper F# Union Identifier: 
+(12): ReSharper F# Unit Of Measure Identifier: 
+(13): ReSharper F# Union Identifier: 
+(14): ReSharper F# Class Identifier: 
+(15): ReSharper F# Type Parameter Identifier: 
+(16): ReSharper F# Union Case Identifier: 
+(17): ReSharper F# Struct Identifier: 
+(18): ReSharper F# Type Parameter Identifier: 
+(19): ReSharper F# Value Identifier: 
+(20): ReSharper F# Union Identifier: 
+(21): ReSharper F# Unit Of Measure Identifier: 
+(22): ReSharper F# Union Case Identifier: 
+(23): ReSharper F# Unit Of Measure Identifier: 
+(24): ReSharper F# Class Identifier: 
+(25): ReSharper F# Class Identifier: 
+(26): ReSharper F# Type Parameter Identifier: 
+(27): ReSharper F# Value Identifier: 
+(28): ReSharper F# Class Identifier: 
+(29): ReSharper F# Unit Of Measure Identifier: 
 (30): ReSharper F# Class Identifier: 
-(31): ReSharper F# Type Parameter Identifier: 
-(32): ReSharper F# Union Case Identifier: 
-(33): ReSharper F# Struct Identifier: 
-(34): ReSharper F# Type Parameter Identifier: 
-(35): ReSharper F# Union Case Identifier: 
-(36): ReSharper F# Struct Identifier: 
-(37): ReSharper F# Type Parameter Identifier: 
-(38): ReSharper F# Value Identifier: 
-(39): ReSharper F# Union Identifier: 
-(40): ReSharper F# Unit Of Measure Identifier: 
-(41): ReSharper F# Union Case Identifier: 
-(42): ReSharper F# Unit Of Measure Identifier: 
-(43): ReSharper F# Class Identifier: 
-(44): ReSharper F# Class Identifier: 
-(45): ReSharper F# Type Parameter Identifier: 
-(46): ReSharper F# Value Identifier: 
-(47): ReSharper F# Struct Identifier: 
-(48): ReSharper F# Type Parameter Identifier: 
-(49): ReSharper F# Value Identifier: 
-(50): ReSharper F# Property Identifier: 
-(51): ReSharper F# Value Identifier: 
-(52): ReSharper F# Value Identifier: 
-(53): ReSharper F# Class Identifier: 
-(54): ReSharper F# Unit Of Measure Identifier: 
-(55): ReSharper F# Unit Of Measure Identifier: 
-(56): ReSharper F# Class Identifier: 
-(57): ReSharper F# Struct Identifier: 
-(58): ReSharper F# Class Identifier: 
-(59): ReSharper F# Type Parameter Identifier: 
-(60): ReSharper F# Value Identifier: 
-(61): ReSharper F# Struct Identifier: 
-(62): ReSharper F# Type Parameter Identifier: 
-(63): ReSharper F# Mutable Value Identifier: 
-(64): ReSharper F# Property Identifier: 
-(65): ReSharper F# Value Identifier: 
-(66): ReSharper F# Value Identifier: 
-(67): ReSharper F# Struct Identifier: 
-(68): ReSharper F# Unit Of Measure Identifier: 
-(69): ReSharper F# Unit Of Measure Identifier: 
+(31): ReSharper F# Struct Identifier: 
+(32): ReSharper F# Class Identifier: 
+(33): ReSharper F# Type Parameter Identifier: 
+(34): ReSharper F# Value Identifier: 
+(35): ReSharper F# Struct Identifier: 
+(36): ReSharper F# Type Parameter Identifier: 
+(37): ReSharper F# Value Identifier: 
+(38): ReSharper F# Struct Identifier: 
+(39): ReSharper F# Unit Of Measure Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 03 - Units of measure.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 03 - Units of measure.fs.gold
@@ -1,55 +1,22 @@
 ﻿[<|Measure|(0)>] type |m|(1)
 
-type |MeasureRecord|(2)<[<|Measure|(3)>] |'u|(4)> = { |x|(5) : |float|(6)<|'u|(7)> }
-let |mrec|(8) : |MeasureRecord|(9)<|m|(10)> = { |x|(11) = 0.0<|m|(12)>; }
+type |IntMeasure|(2) = |int|(3)<|m|(4)>
 
-type |MeasureDiscriminatedUnion|(13)<[<|Measure|(14)>] |'a|(15)> = | |IntMeasureMember|(16) of |decimal|(17)<|'a|(18)>
-let |mdu|(19) = |MeasureDiscriminatedUnion|(20)<|m|(21)>.|IntMeasureMember|(22) 10m<|m|(23)>
-
-type |MeasureClass|(24)<[<|Measure|(25)>] |'a|(26)>() = class end    
-let |mcls|(27) = |MeasureClass|(28)<|m|(29)>()
-
-[<|Struct|(30)>]
-type |MeasureStruct|(31)<[<|Measure|(32)>] |'a|(33)>(|__|(34) : |int|(35)<|'a|(36)>) = struct end
-let |mstr|(37) = |MeasureStruct|(38)<|m|(39)>()
+type |MeasureClass|(5)<[<|Measure|(6)>] |'a|(7)>() = class end
+let |mclsctor|(8) = |MeasureClass|(9)<|m|(10)>
+let |mcls|(11) = |MeasureClass|(12)<|m|(13)>()
 ---------------------------------------------------------
 (0): ReSharper F# Class Identifier: 
 (1): ReSharper F# Unit Of Measure Identifier: 
-(2): ReSharper F# Record Identifier: 
-(3): ReSharper F# Class Identifier: 
-(4): ReSharper F# Type Parameter Identifier: 
-(5): ReSharper F# Field Identifier: 
-(6): ReSharper F# Struct Identifier: 
+(2): ReSharper F# Struct Identifier: 
+(3): ReSharper F# Struct Identifier: 
+(4): ReSharper F# Unit Of Measure Identifier: 
+(5): ReSharper F# Class Identifier: 
+(6): ReSharper F# Class Identifier: 
 (7): ReSharper F# Type Parameter Identifier: 
-(8): ReSharper F# Value Identifier: 
-(9): ReSharper F# Record Identifier: 
+(8): ReSharper F# Function Identifier: 
+(9): ReSharper F# Class Identifier: 
 (10): ReSharper F# Unit Of Measure Identifier: 
-(11): ReSharper F# Field Identifier: 
-(12): ReSharper F# Unit Of Measure Identifier: 
-(13): ReSharper F# Union Identifier: 
-(14): ReSharper F# Class Identifier: 
-(15): ReSharper F# Type Parameter Identifier: 
-(16): ReSharper F# Union Case Identifier: 
-(17): ReSharper F# Struct Identifier: 
-(18): ReSharper F# Type Parameter Identifier: 
-(19): ReSharper F# Value Identifier: 
-(20): ReSharper F# Union Identifier: 
-(21): ReSharper F# Unit Of Measure Identifier: 
-(22): ReSharper F# Union Case Identifier: 
-(23): ReSharper F# Unit Of Measure Identifier: 
-(24): ReSharper F# Class Identifier: 
-(25): ReSharper F# Class Identifier: 
-(26): ReSharper F# Type Parameter Identifier: 
-(27): ReSharper F# Value Identifier: 
-(28): ReSharper F# Class Identifier: 
-(29): ReSharper F# Unit Of Measure Identifier: 
-(30): ReSharper F# Class Identifier: 
-(31): ReSharper F# Struct Identifier: 
-(32): ReSharper F# Class Identifier: 
-(33): ReSharper F# Type Parameter Identifier: 
-(34): ReSharper F# Value Identifier: 
-(35): ReSharper F# Struct Identifier: 
-(36): ReSharper F# Type Parameter Identifier: 
-(37): ReSharper F# Value Identifier: 
-(38): ReSharper F# Struct Identifier: 
-(39): ReSharper F# Unit Of Measure Identifier: 
+(11): ReSharper F# Value Identifier: 
+(12): ReSharper F# Class Identifier: 
+(13): ReSharper F# Unit Of Measure Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 03 - Units of measure.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 03 - Units of measure.fs.gold
@@ -1,0 +1,92 @@
+﻿[<|Measure|(0)>] type |m|(1)
+[<|Measure|(2)>] type |s|(3)
+
+type |MeasureBasicType|(4) = |int|(5)<|m|(6)/|s|(7)>
+
+type |MeasureRecord|(8)<[<|Measure|(9)>] |'u|(10)> = { |x|(11) : |float|(12)<|'u|(13)>; |y|(14) : |float|(15)<|'u|(16)>; |z|(17) : |float|(18)<|'u|(19)> }
+let |mrec|(20) : |MeasureRecord|(21)<|m|(22)> = { |x|(23) = 0.0<|m|(24)>; |y|(25) = 0.0<|m|(26)>; |z|(27) = 0.0<|m|(28)> }
+
+type |MeasureDiscriminatedUnion|(29)<[<|Measure|(30)>] |'a|(31)> =
+    | |IntMeasureMember|(32) of |int|(33)<|'a|(34)>
+    | |FloatMeasureMember|(35) of |float|(36)<|'a|(37)>
+let |mdu|(38) = |MeasureDiscriminatedUnion|(39)<|s|(40)>.|IntMeasureMember|(41) 10<|s|(42)>
+
+type |MeasureClass|(43)<[<|Measure|(44)>] |'a|(45)>(|value|(46) : |int|(47)<|'a|(48)>) =
+    member |x|(49).|Value|(50) = |value|(51)
+let |mcls|(52) = |MeasureClass|(53)<|s|(54)> 10<|s|(55)>
+
+[<|Struct|(56)>]
+type |MeasureStruct|(57)<[<|Measure|(58)>] |'a|(59)>(|value|(60) : |int|(61)<|'a|(62)>) =
+    member |x|(63).|Value|(64) = |value|(65)    
+let |mstr|(66) = |MeasureStruct|(67)<|s|(68)> 10<|s|(69)>
+---------------------------------------------------------
+(0): ReSharper F# Class Identifier: 
+(1): ReSharper F# Unit Of Measure Identifier: 
+(2): ReSharper F# Class Identifier: 
+(3): ReSharper F# Unit Of Measure Identifier: 
+(4): ReSharper F# Struct Identifier: 
+(5): ReSharper F# Struct Identifier: 
+(6): ReSharper F# Unit Of Measure Identifier: 
+(7): ReSharper F# Unit Of Measure Identifier: 
+(8): ReSharper F# Record Identifier: 
+(9): ReSharper F# Class Identifier: 
+(10): ReSharper F# Type Parameter Identifier: 
+(11): ReSharper F# Field Identifier: 
+(12): ReSharper F# Struct Identifier: 
+(13): ReSharper F# Type Parameter Identifier: 
+(14): ReSharper F# Field Identifier: 
+(15): ReSharper F# Struct Identifier: 
+(16): ReSharper F# Type Parameter Identifier: 
+(17): ReSharper F# Field Identifier: 
+(18): ReSharper F# Struct Identifier: 
+(19): ReSharper F# Type Parameter Identifier: 
+(20): ReSharper F# Value Identifier: 
+(21): ReSharper F# Record Identifier: 
+(22): ReSharper F# Unit Of Measure Identifier: 
+(23): ReSharper F# Field Identifier: 
+(24): ReSharper F# Unit Of Measure Identifier: 
+(25): ReSharper F# Field Identifier: 
+(26): ReSharper F# Unit Of Measure Identifier: 
+(27): ReSharper F# Field Identifier: 
+(28): ReSharper F# Unit Of Measure Identifier: 
+(29): ReSharper F# Union Identifier: 
+(30): ReSharper F# Class Identifier: 
+(31): ReSharper F# Type Parameter Identifier: 
+(32): ReSharper F# Union Case Identifier: 
+(33): ReSharper F# Struct Identifier: 
+(34): ReSharper F# Type Parameter Identifier: 
+(35): ReSharper F# Union Case Identifier: 
+(36): ReSharper F# Struct Identifier: 
+(37): ReSharper F# Type Parameter Identifier: 
+(38): ReSharper F# Value Identifier: 
+(39): ReSharper F# Union Identifier: 
+(40): ReSharper F# Unit Of Measure Identifier: 
+(41): ReSharper F# Union Case Identifier: 
+(42): ReSharper F# Unit Of Measure Identifier: 
+(43): ReSharper F# Class Identifier: 
+(44): ReSharper F# Class Identifier: 
+(45): ReSharper F# Type Parameter Identifier: 
+(46): ReSharper F# Value Identifier: 
+(47): ReSharper F# Struct Identifier: 
+(48): ReSharper F# Type Parameter Identifier: 
+(49): ReSharper F# Value Identifier: 
+(50): ReSharper F# Property Identifier: 
+(51): ReSharper F# Value Identifier: 
+(52): ReSharper F# Value Identifier: 
+(53): ReSharper F# Class Identifier: 
+(54): ReSharper F# Unit Of Measure Identifier: 
+(55): ReSharper F# Unit Of Measure Identifier: 
+(56): ReSharper F# Class Identifier: 
+(57): ReSharper F# Struct Identifier: 
+(58): ReSharper F# Class Identifier: 
+(59): ReSharper F# Type Parameter Identifier: 
+(60): ReSharper F# Value Identifier: 
+(61): ReSharper F# Struct Identifier: 
+(62): ReSharper F# Type Parameter Identifier: 
+(63): ReSharper F# Mutable Value Identifier: 
+(64): ReSharper F# Property Identifier: 
+(65): ReSharper F# Value Identifier: 
+(66): ReSharper F# Value Identifier: 
+(67): ReSharper F# Struct Identifier: 
+(68): ReSharper F# Unit Of Measure Identifier: 
+(69): ReSharper F# Unit Of Measure Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 03 - Units of measure.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 03 - Units of measure.fs.gold
@@ -3,8 +3,9 @@
 type |IntMeasure|(2) = |int|(3)<|m|(4)>
 
 type |MeasureClass|(5)<[<|Measure|(6)>] |'a|(7)>() = class end
-let |mclsctor|(8) = |MeasureClass|(9)<|m|(10)>
-let |mcls|(11) = |MeasureClass|(12)<|m|(13)>()
+
+let _: |MeasureClass|(8)<|m|(9)> = |MeasureClass|(10)<|m|(11)>()
+
 ---------------------------------------------------------
 (0): ReSharper F# Class Identifier: 
 (1): ReSharper F# Unit Of Measure Identifier: 
@@ -14,9 +15,7 @@ let |mcls|(11) = |MeasureClass|(12)<|m|(13)>()
 (5): ReSharper F# Class Identifier: 
 (6): ReSharper F# Class Identifier: 
 (7): ReSharper F# Type Parameter Identifier: 
-(8): ReSharper F# Function Identifier: 
-(9): ReSharper F# Class Identifier: 
-(10): ReSharper F# Unit Of Measure Identifier: 
-(11): ReSharper F# Value Identifier: 
-(12): ReSharper F# Class Identifier: 
-(13): ReSharper F# Unit Of Measure Identifier: 
+(8): ReSharper F# Class Identifier: 
+(9): ReSharper F# Unit Of Measure Identifier: 
+(10): ReSharper F# Class Identifier: 
+(11): ReSharper F# Unit Of Measure Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 04 - Core abbreviations.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 04 - Core abbreviations.fs
@@ -6,3 +6,9 @@ let testList (ls : int list) =
 
 let testSeq (sq : int seq) =
     sq
+	
+let testRszArr (rsz : int ResizeArray) =
+    rsz
+    
+let testOpt (io : int option) =
+    io

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 04 - Core abbreviations.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 04 - Core abbreviations.fs
@@ -1,14 +1,9 @@
-let testArr (ar : int array) =
-   ar
+let testArr (ar : int array) = ar
 
-let testList (ls : int list) =
-    ls
+let testList (ls : int list) = ls
 
-let testSeq (sq : int seq) =
-    sq
+let testSeq (sq : int seq) = sq
 	
-let testRszArr (rsz : int ResizeArray) =
-    rsz
+let testRszArr (rsz : int ResizeArray) = rsz
     
-let testOpt (io : int option) =
-    io
+let testOpt (io : int option) = io

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 04 - Core abbreviations.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 04 - Core abbreviations.fs
@@ -1,0 +1,8 @@
+let testArr (ar : int array) =
+   ar
+
+let testList (ls : int list) =
+    ls
+
+let testSeq (sq : int seq) =
+    sq

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 04 - Core abbreviations.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 04 - Core abbreviations.fs
@@ -1,9 +1,5 @@
-let testArr (ar : int array) = ar
-
-let testList (ls : int list) = ls
-
-let testSeq (sq : int seq) = sq
-	
-let testRszArr (rsz : int ResizeArray) = rsz
-    
-let testOpt (io : int option) = io
+type T1 = int array
+type T2 = int list
+type T3 = int seq
+type T4 = int ResizeArray
+type T5 = int option

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 04 - Core abbreviations.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 04 - Core abbreviations.fs.gold
@@ -6,6 +6,12 @@ let |testList|(5) (|ls|(6) : |int|(7) |list|(8)) =
 
 let |testSeq|(10) (|sq|(11) : |int|(12) |seq|(13)) =
     |sq|(14)
+	
+let |testRszArr|(15) (|rsz|(16) : |int|(17) |ResizeArray|(18)) =
+    |rsz|(19)
+    
+let |testOpt|(20) (|io|(21) : |int|(22) |option|(23)) =
+    |io|(24)
 ---------------------------------------------------------
 (0): ReSharper F# Function Identifier: 
 (1): ReSharper F# Value Identifier: 
@@ -22,3 +28,13 @@ let |testSeq|(10) (|sq|(11) : |int|(12) |seq|(13)) =
 (12): ReSharper F# Struct Identifier: 
 (13): ReSharper F# Interface Identifier: 
 (14): ReSharper F# Value Identifier: 
+(15): ReSharper F# Function Identifier: 
+(16): ReSharper F# Value Identifier: 
+(17): ReSharper F# Struct Identifier: 
+(18): ReSharper F# Class Identifier: 
+(19): ReSharper F# Value Identifier: 
+(20): ReSharper F# Function Identifier: 
+(21): ReSharper F# Value Identifier: 
+(22): ReSharper F# Struct Identifier: 
+(23): ReSharper F# Union Identifier: 
+(24): ReSharper F# Value Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 04 - Core abbreviations.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 04 - Core abbreviations.fs.gold
@@ -1,17 +1,12 @@
-﻿let |testArr|(0) (|ar|(1) : |int|(2) |array|(3)) =
-   |ar|(4)
+﻿let |testArr|(0) (|ar|(1) : |int|(2) |array|(3)) = |ar|(4)
 
-let |testList|(5) (|ls|(6) : |int|(7) |list|(8)) =
-    |ls|(9)
+let |testList|(5) (|ls|(6) : |int|(7) |list|(8)) = |ls|(9)
 
-let |testSeq|(10) (|sq|(11) : |int|(12) |seq|(13)) =
-    |sq|(14)
+let |testSeq|(10) (|sq|(11) : |int|(12) |seq|(13)) = |sq|(14)
 	
-let |testRszArr|(15) (|rsz|(16) : |int|(17) |ResizeArray|(18)) =
-    |rsz|(19)
+let |testRszArr|(15) (|rsz|(16) : |int|(17) |ResizeArray|(18)) = |rsz|(19)
     
-let |testOpt|(20) (|io|(21) : |int|(22) |option|(23)) =
-    |io|(24)
+let |testOpt|(20) (|io|(21) : |int|(22) |option|(23)) = |io|(24)
 ---------------------------------------------------------
 (0): ReSharper F# Function Identifier: 
 (1): ReSharper F# Value Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 04 - Core abbreviations.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 04 - Core abbreviations.fs.gold
@@ -1,35 +1,22 @@
-﻿let |testArr|(0) (|ar|(1) : |int|(2) |array|(3)) = |ar|(4)
+﻿type |T1|(0) = |int|(1) |array|(2)
+type |T2|(3) = |int|(4) |list|(5)
+type |T3|(6) = |int|(7) |seq|(8)
+type |T4|(9) = |int|(10) |ResizeArray|(11)
+type |T5|(12) = |int|(13) |option|(14)
 
-let |testList|(5) (|ls|(6) : |int|(7) |list|(8)) = |ls|(9)
-
-let |testSeq|(10) (|sq|(11) : |int|(12) |seq|(13)) = |sq|(14)
-	
-let |testRszArr|(15) (|rsz|(16) : |int|(17) |ResizeArray|(18)) = |rsz|(19)
-    
-let |testOpt|(20) (|io|(21) : |int|(22) |option|(23)) = |io|(24)
 ---------------------------------------------------------
-(0): ReSharper F# Function Identifier: 
-(1): ReSharper F# Value Identifier: 
-(2): ReSharper F# Struct Identifier: 
-(3): ReSharper F# Class Identifier: 
-(4): ReSharper F# Value Identifier: 
-(5): ReSharper F# Function Identifier: 
-(6): ReSharper F# Value Identifier: 
+(0): ReSharper F# Class Identifier: 
+(1): ReSharper F# Struct Identifier: 
+(2): ReSharper F# Class Identifier: 
+(3): ReSharper F# Union Identifier: 
+(4): ReSharper F# Struct Identifier: 
+(5): ReSharper F# Union Identifier: 
+(6): ReSharper F# Interface Identifier: 
 (7): ReSharper F# Struct Identifier: 
-(8): ReSharper F# Union Identifier: 
-(9): ReSharper F# Value Identifier: 
-(10): ReSharper F# Function Identifier: 
-(11): ReSharper F# Value Identifier: 
-(12): ReSharper F# Struct Identifier: 
-(13): ReSharper F# Interface Identifier: 
-(14): ReSharper F# Value Identifier: 
-(15): ReSharper F# Function Identifier: 
-(16): ReSharper F# Value Identifier: 
-(17): ReSharper F# Struct Identifier: 
-(18): ReSharper F# Class Identifier: 
-(19): ReSharper F# Value Identifier: 
-(20): ReSharper F# Function Identifier: 
-(21): ReSharper F# Value Identifier: 
-(22): ReSharper F# Struct Identifier: 
-(23): ReSharper F# Union Identifier: 
-(24): ReSharper F# Value Identifier: 
+(8): ReSharper F# Interface Identifier: 
+(9): ReSharper F# Class Identifier: 
+(10): ReSharper F# Struct Identifier: 
+(11): ReSharper F# Class Identifier: 
+(12): ReSharper F# Union Identifier: 
+(13): ReSharper F# Struct Identifier: 
+(14): ReSharper F# Union Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 04 - Core abbreviations.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Type aliases 04 - Core abbreviations.fs.gold
@@ -1,0 +1,24 @@
+﻿let |testArr|(0) (|ar|(1) : |int|(2) |array|(3)) =
+   |ar|(4)
+
+let |testList|(5) (|ls|(6) : |int|(7) |list|(8)) =
+    |ls|(9)
+
+let |testSeq|(10) (|sq|(11) : |int|(12) |seq|(13)) =
+    |sq|(14)
+---------------------------------------------------------
+(0): ReSharper F# Function Identifier: 
+(1): ReSharper F# Value Identifier: 
+(2): ReSharper F# Struct Identifier: 
+(3): ReSharper F# Class Identifier: 
+(4): ReSharper F# Value Identifier: 
+(5): ReSharper F# Function Identifier: 
+(6): ReSharper F# Value Identifier: 
+(7): ReSharper F# Struct Identifier: 
+(8): ReSharper F# Union Identifier: 
+(9): ReSharper F# Value Identifier: 
+(10): ReSharper F# Function Identifier: 
+(11): ReSharper F# Value Identifier: 
+(12): ReSharper F# Struct Identifier: 
+(13): ReSharper F# Interface Identifier: 
+(14): ReSharper F# Value Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Union case 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Union case 01.fs.gold
@@ -8,5 +8,5 @@ type |U|(1) =
 (0): ReSharper F# Module Identifier: 
 (1): ReSharper F# Union Identifier: 
 (2): ReSharper F# Union Case Identifier: 
-(3): ReSharper F# Class Identifier: 
+(3): ReSharper F# Struct Identifier: 
 (4): ReSharper F# Union Case Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Units of measure.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Units of measure.fs.gold
@@ -10,7 +10,7 @@ let |xvec|(8): |vector3D|(9)<|m|(10)> = { |x|(11) = 0.0<|m|(12)> }
 (3): ReSharper F# Class Identifier: 
 (4): ReSharper F# Type Parameter Identifier: 
 (5): ReSharper F# Field Identifier: 
-(6): ReSharper F# Class Identifier: 
+(6): ReSharper F# Struct Identifier: 
 (7): ReSharper F# Type Parameter Identifier: 
 (8): ReSharper F# Value Identifier: 
 (9): ReSharper F# Record Identifier: 

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Daemon/IdentifierHighlightingTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Daemon/IdentifierHighlightingTest.fs
@@ -30,25 +30,23 @@ type IdentifierHighlightingTest() =
     [<Test>] member x.``Byrefs 01``() = x.DoNamedTest()
 
     [<Test>] member x.``Union case 01``() = x.DoNamedTest()
-    
+
     [<Test>] member x.``Extension members 01``() = x.DoNamedTest()
-    
+
     [<TestReferences("System", "System.Core")>]
     [<Test>] member x.``Extension members 02``() = x.DoNamedTest()    
-    
+
     [<TestReferences("System")>]
     [<Test>] member x.``Functions 01``() = x.DoNamedTest()
-    
+
     [<Test>] member x.``Functions 02``() = x.DoNamedTest()
-    
+
     [<Test>] member x.``Computation expressions``() = x.DoNamedTest()
-    
+
     [<Test>] member x.``Units of measure``() = x.DoNamedTest()
-    
+
     [<TestReferences("System")>]
     [<Test>] member x.``Type aliases 01 - Simple types with System dependence``() = x.DoNamedTest()
     [<Test>] member x.``Type aliases 02 - Simple types without System dependence``() = x.DoNamedTest()
     [<Test>] member x.``Type aliases 03 - Units of Measure``() = x.DoNamedTest()
     [<Test>] member x.``Type aliases 04 - Core abbreviations``() = x.DoNamedTest()
-    
-    

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Daemon/IdentifierHighlightingTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Daemon/IdentifierHighlightingTest.fs
@@ -44,3 +44,11 @@ type IdentifierHighlightingTest() =
     [<Test>] member x.``Computation expressions``() = x.DoNamedTest()
     
     [<Test>] member x.``Units of measure``() = x.DoNamedTest()
+    
+    [<TestReferences("System")>]
+    [<Test>] member x.``Type aliases 01 - Simple types with System dependence``() = x.DoNamedTest()
+    [<Test>] member x.``Type aliases 02 - Simple types without System dependence``() = x.DoNamedTest()
+    [<Test>] member x.``Type aliases 03 - Units of Measure``() = x.DoNamedTest()
+    [<Test>] member x.``Type aliases 04 - Core abbreviations``() = x.DoNamedTest()
+    
+    


### PR DESCRIPTION
Improved type abbreviations highlighting: records remain records, structures remain structures etc
Before (Rider 2020.1):
![image](https://user-images.githubusercontent.com/37334640/84957077-227f2e80-b103-11ea-99d5-8cfefcad4785.png)
After (Rider 2020.2 with new highlighting options):
![image](https://user-images.githubusercontent.com/37334640/84957103-32970e00-b103-11ea-97e5-1b5052654555.png)

