### PR TITLE
Function types are now highlighted as delegates.

### DIFF
--- a/ReSharper.FSharp/src/Daemon.FSharp/src/FSharpSymbolHighlightingUtil.cs
+++ b/ReSharper.FSharp/src/Daemon.FSharp/src/FSharpSymbolHighlightingUtil.cs
@@ -41,6 +41,9 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Daemon.Cs
       
       if (entity.IsValueType || entity.HasMeasureParameter())
         return FSharpHighlightingAttributeIdsModule.Struct;
+
+      if (entity.IsFSharpAbbreviation && entity.AbbreviatedType.IsFunctionType)
+        return FSharpHighlightingAttributeIdsModule.Delegate;
       
       return FSharpHighlightingAttributeIdsModule.Class;
     }
@@ -76,15 +79,15 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Daemon.Cs
       if (IsMangledOpName(mfv.LogicalName))
         return FSharpHighlightingAttributeIdsModule.Operator;
 
-      if (mfv.FullType.IsFunctionType || mfv.IsTypeFunction)
+      var fsType = mfv.FullType;
+      if (fsType.IsFunctionType || mfv.IsTypeFunction || fsType.IsAbbreviation && fsType.AbbreviatedType.IsFunctionType)
         return mfv.IsMutable
           ? FSharpHighlightingAttributeIdsModule.MutableFunction
           : FSharpHighlightingAttributeIdsModule.Function;
-
+      
       if (mfv.IsMutable || mfv.IsRefCell())
         return FSharpHighlightingAttributeIdsModule.MutableValue;
 
-      var fsType = mfv.FullType;
       if (fsType.HasTypeDefinition && fsType.TypeDefinition is var mfvTypeEntity && mfvTypeEntity.IsByRef)
         return FSharpHighlightingAttributeIdsModule.MutableValue;
 
@@ -97,7 +100,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Daemon.Cs
       switch (symbol)
       {
         case FSharpEntity entity when !entity.IsUnresolved:
-          return GetEntityHighlightingAttributeId(entity.GetAbbreviatedType());
+          return GetEntityHighlightingAttributeId(entity.GetAbbreviatedEntity());
 
         case FSharpMemberOrFunctionOrValue mfv when !mfv.IsUnresolved:
           return GetMfvHighlightingAttributeId(mfv.AccessorProperty?.Value ?? mfv);

--- a/ReSharper.FSharp/src/Daemon.FSharp/src/FSharpSymbolHighlightingUtil.cs
+++ b/ReSharper.FSharp/src/Daemon.FSharp/src/FSharpSymbolHighlightingUtil.cs
@@ -84,7 +84,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Daemon.Cs
         return mfv.IsMutable
           ? FSharpHighlightingAttributeIdsModule.MutableFunction
           : FSharpHighlightingAttributeIdsModule.Function;
-      
+
       if (mfv.IsMutable || mfv.IsRefCell())
         return FSharpHighlightingAttributeIdsModule.MutableValue;
 

--- a/ReSharper.FSharp/src/FSharp.Common/src/Util/FSharpHighlightingAttributeIds.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/Util/FSharpHighlightingAttributeIds.fs
@@ -391,7 +391,7 @@ type FSharpSettingsNamesProvider() =
       FSharpHighlightingAttributeIds.ExtensionProperty,
       FallbackAttributeId = FSharpHighlightingAttributeIds.Property,
       GroupId = FSharpHighlightingAttributeIds.GroupId,
-      RiderPresentableName = "Members//Extensions property",
+      RiderPresentableName = "Members//Extension property",
       Layer = HighlighterLayer.SYNTAX,
       VSPriority = VSPriority.IDENTIFIERS,
       EffectType = EffectType.TEXT, ForegroundColor = "Purple", DarkForegroundColor = "Violet")>]

--- a/ReSharper.FSharp/src/FSharp.Common/src/Util/FSharpSymbolUtil.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/Util/FSharpSymbolUtil.fs
@@ -146,8 +146,8 @@ let patternName (pattern: FSharpActivePatternGroup) =
     let wildCase = if pattern.IsTotal then "|" else "_|"
     "|" + joinedNames + wildCase
     
-[<Extension; CompiledName("GetAbbreviatedType")>]
-let getAbbreviatedType (entity: FSharpEntity) =
+[<Extension; CompiledName("GetAbbreviatedEntity")>]
+let getAbbreviatedEntity (entity: FSharpEntity) =
     let mutable baseTypeEntity = entity
     while baseTypeEntity.IsFSharpAbbreviation && baseTypeEntity.AbbreviatedType.HasTypeDefinition do
         baseTypeEntity <- baseTypeEntity.AbbreviatedType.TypeDefinition

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 01.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 01.fs
@@ -1,0 +1,8 @@
+open System
+
+type T1 = delegate of unit -> unit
+type T2 = delegate of int -> int
+type T3 = Func<int, unt>
+type T4 = Action<int>
+type T5 = int -> int
+type T6 = T5

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 01.fs.gold
@@ -1,0 +1,28 @@
+﻿open |System|(0)
+
+type |T1|(1) = delegate of |unit|(2) -> |unit|(3)
+type |T2|(4) = delegate of |int|(5) -> |int|(6)
+type |T3|(7) = |Func|(8)<|int|(9), unt>
+type |T4|(10) = |Action|(11)<|int|(12)>
+type |T5|(13) = |int|(14) -> |int|(15)
+type |T6|(16) = |T5|(17)
+
+---------------------------------------------------------
+(0): ReSharper F# Namespace Identifier: 
+(1): ReSharper F# Delegate Identifier: 
+(2): ReSharper F# Class Identifier: 
+(3): ReSharper F# Class Identifier: 
+(4): ReSharper F# Delegate Identifier: 
+(5): ReSharper F# Struct Identifier: 
+(6): ReSharper F# Struct Identifier: 
+(7): ReSharper F# Class Identifier: 
+(8): ReSharper F# Delegate Identifier: 
+(9): ReSharper F# Struct Identifier: 
+(10): ReSharper F# Delegate Identifier: 
+(11): ReSharper F# Delegate Identifier: 
+(12): ReSharper F# Struct Identifier: 
+(13): ReSharper F# Delegate Identifier: 
+(14): ReSharper F# Struct Identifier: 
+(15): ReSharper F# Struct Identifier: 
+(16): ReSharper F# Delegate Identifier: 
+(17): ReSharper F# Delegate Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 02.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 02.fs
@@ -1,10 +1,7 @@
 open System
 
 type T1 = int -> int
-type T2 = T1
-type T3 = T2
 
 let f1 (f : T1) = f 1
-let f2 (f : T3) = f 1
-let f3 (f : int -> int) = f 1
-let f4 (f : Func<int, int>) = f.Invoke(1)
+let f2 (f : int -> int) = f 1
+let f3 (f : Func<int, int>) = f.Invoke(1)

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 02.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 02.fs
@@ -1,7 +1,10 @@
 open System
 
 type T1 = int -> int
+type T2 = T1
+type T3 = T2
 
 let f1 (f : T1) = f 1
-let f2 (f : Func<int, int>) = f.Invoke(1)
+let f2 (f : T3) = f 1
 let f3 (f : int -> int) = f 1
+let f4 (f : Func<int, int>) = f.Invoke(1)

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 02.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 02.fs
@@ -1,0 +1,7 @@
+open System
+
+type T1 = int -> int
+
+let f1 (f : T1) = f 1
+let f2 (f : Func<int, int>) = f.Invoke(1)
+let f3 (f : int -> int) = f 1

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 02.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 02.fs.gold
@@ -1,0 +1,29 @@
+﻿open |System|(0)
+
+type |T1|(1) = |int|(2) -> |int|(3)
+
+let |f1|(4) (|f|(5) : |T1|(6)) = |f|(7) 1
+let |f2|(8) (|f|(9) : |Func|(10)<|int|(11), |int|(12)>) = |f|(13).|Invoke|(14)(1)
+let |f3|(15) (|f|(16) : |int|(17) -> |int|(18)) = |f|(19) 1
+
+---------------------------------------------------------
+(0): ReSharper F# Namespace Identifier: 
+(1): ReSharper F# Delegate Identifier: 
+(2): ReSharper F# Struct Identifier: 
+(3): ReSharper F# Struct Identifier: 
+(4): ReSharper F# Function Identifier: 
+(5): ReSharper F# Function Identifier: 
+(6): ReSharper F# Delegate Identifier: 
+(7): ReSharper F# Function Identifier: 
+(8): ReSharper F# Function Identifier: 
+(9): ReSharper F# Value Identifier: 
+(10): ReSharper F# Delegate Identifier: 
+(11): ReSharper F# Struct Identifier: 
+(12): ReSharper F# Struct Identifier: 
+(13): ReSharper F# Value Identifier: 
+(14): ReSharper F# Method Identifier: 
+(15): ReSharper F# Function Identifier: 
+(16): ReSharper F# Function Identifier: 
+(17): ReSharper F# Struct Identifier: 
+(18): ReSharper F# Struct Identifier: 
+(19): ReSharper F# Function Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 02.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 02.fs.gold
@@ -1,40 +1,29 @@
 ﻿open |System|(0)
 
 type |T1|(1) = |int|(2) -> |int|(3)
-type |T2|(4) = |T1|(5)
-type |T3|(6) = |T2|(7)
 
-let |f1|(8) (|f|(9) : |T1|(10)) = |f|(11) 1
-let |f2|(12) (|f|(13) : |T3|(14)) = |f|(15) 1
-let |f3|(16) (|f|(17) : |int|(18) -> |int|(19)) = |f|(20) 1
-let |f4|(21) (|f|(22) : |Func|(23)<|int|(24), |int|(25)>) = |f|(26).|Invoke|(27)(1)
+let |f1|(4) (|f|(5) : |T1|(6)) = |f|(7) 1
+let |f2|(8) (|f|(9) : |int|(10) -> |int|(11)) = |f|(12) 1
+let |f3|(13) (|f|(14) : |Func|(15)<|int|(16), |int|(17)>) = |f|(18).|Invoke|(19)(1)
 
 ---------------------------------------------------------
 (0): ReSharper F# Namespace Identifier: 
 (1): ReSharper F# Delegate Identifier: 
 (2): ReSharper F# Struct Identifier: 
 (3): ReSharper F# Struct Identifier: 
-(4): ReSharper F# Delegate Identifier: 
-(5): ReSharper F# Delegate Identifier: 
+(4): ReSharper F# Function Identifier: 
+(5): ReSharper F# Function Identifier: 
 (6): ReSharper F# Delegate Identifier: 
-(7): ReSharper F# Delegate Identifier: 
+(7): ReSharper F# Function Identifier: 
 (8): ReSharper F# Function Identifier: 
 (9): ReSharper F# Function Identifier: 
-(10): ReSharper F# Delegate Identifier: 
-(11): ReSharper F# Function Identifier: 
+(10): ReSharper F# Struct Identifier: 
+(11): ReSharper F# Struct Identifier: 
 (12): ReSharper F# Function Identifier: 
 (13): ReSharper F# Function Identifier: 
-(14): ReSharper F# Delegate Identifier: 
-(15): ReSharper F# Function Identifier: 
-(16): ReSharper F# Function Identifier: 
-(17): ReSharper F# Function Identifier: 
-(18): ReSharper F# Struct Identifier: 
-(19): ReSharper F# Struct Identifier: 
-(20): ReSharper F# Function Identifier: 
-(21): ReSharper F# Function Identifier: 
-(22): ReSharper F# Value Identifier: 
-(23): ReSharper F# Delegate Identifier: 
-(24): ReSharper F# Struct Identifier: 
-(25): ReSharper F# Struct Identifier: 
-(26): ReSharper F# Value Identifier: 
-(27): ReSharper F# Method Identifier: 
+(14): ReSharper F# Value Identifier: 
+(15): ReSharper F# Delegate Identifier: 
+(16): ReSharper F# Struct Identifier: 
+(17): ReSharper F# Struct Identifier: 
+(18): ReSharper F# Value Identifier: 
+(19): ReSharper F# Method Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 02.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 02.fs.gold
@@ -1,29 +1,40 @@
 ﻿open |System|(0)
 
 type |T1|(1) = |int|(2) -> |int|(3)
+type |T2|(4) = |T1|(5)
+type |T3|(6) = |T2|(7)
 
-let |f1|(4) (|f|(5) : |T1|(6)) = |f|(7) 1
-let |f2|(8) (|f|(9) : |Func|(10)<|int|(11), |int|(12)>) = |f|(13).|Invoke|(14)(1)
-let |f3|(15) (|f|(16) : |int|(17) -> |int|(18)) = |f|(19) 1
+let |f1|(8) (|f|(9) : |T1|(10)) = |f|(11) 1
+let |f2|(12) (|f|(13) : |T3|(14)) = |f|(15) 1
+let |f3|(16) (|f|(17) : |int|(18) -> |int|(19)) = |f|(20) 1
+let |f4|(21) (|f|(22) : |Func|(23)<|int|(24), |int|(25)>) = |f|(26).|Invoke|(27)(1)
 
 ---------------------------------------------------------
 (0): ReSharper F# Namespace Identifier: 
 (1): ReSharper F# Delegate Identifier: 
 (2): ReSharper F# Struct Identifier: 
 (3): ReSharper F# Struct Identifier: 
-(4): ReSharper F# Function Identifier: 
-(5): ReSharper F# Function Identifier: 
+(4): ReSharper F# Delegate Identifier: 
+(5): ReSharper F# Delegate Identifier: 
 (6): ReSharper F# Delegate Identifier: 
-(7): ReSharper F# Function Identifier: 
+(7): ReSharper F# Delegate Identifier: 
 (8): ReSharper F# Function Identifier: 
-(9): ReSharper F# Value Identifier: 
+(9): ReSharper F# Function Identifier: 
 (10): ReSharper F# Delegate Identifier: 
-(11): ReSharper F# Struct Identifier: 
-(12): ReSharper F# Struct Identifier: 
-(13): ReSharper F# Value Identifier: 
-(14): ReSharper F# Method Identifier: 
+(11): ReSharper F# Function Identifier: 
+(12): ReSharper F# Function Identifier: 
+(13): ReSharper F# Function Identifier: 
+(14): ReSharper F# Delegate Identifier: 
 (15): ReSharper F# Function Identifier: 
 (16): ReSharper F# Function Identifier: 
-(17): ReSharper F# Struct Identifier: 
+(17): ReSharper F# Function Identifier: 
 (18): ReSharper F# Struct Identifier: 
-(19): ReSharper F# Function Identifier: 
+(19): ReSharper F# Struct Identifier: 
+(20): ReSharper F# Function Identifier: 
+(21): ReSharper F# Function Identifier: 
+(22): ReSharper F# Value Identifier: 
+(23): ReSharper F# Delegate Identifier: 
+(24): ReSharper F# Struct Identifier: 
+(25): ReSharper F# Struct Identifier: 
+(26): ReSharper F# Value Identifier: 
+(27): ReSharper F# Method Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 03.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 03.fs
@@ -1,0 +1,9 @@
+open System
+
+type T1 = int -> int
+type T2 = T1
+type T3 = T2
+type T4 = T3
+
+let f1 (f : T4) = f 1
+

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 03.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates 03.fs.gold
@@ -1,0 +1,25 @@
+﻿open |System|(0)
+
+type |T1|(1) = |int|(2) -> |int|(3)
+type |T2|(4) = |T1|(5)
+type |T3|(6) = |T2|(7)
+type |T4|(8) = |T3|(9)
+
+let |f1|(10) (|f|(11) : |T4|(12)) = |f|(13) 1
+
+
+---------------------------------------------------------
+(0): ReSharper F# Namespace Identifier: 
+(1): ReSharper F# Delegate Identifier: 
+(2): ReSharper F# Struct Identifier: 
+(3): ReSharper F# Struct Identifier: 
+(4): ReSharper F# Delegate Identifier: 
+(5): ReSharper F# Delegate Identifier: 
+(6): ReSharper F# Delegate Identifier: 
+(7): ReSharper F# Delegate Identifier: 
+(8): ReSharper F# Delegate Identifier: 
+(9): ReSharper F# Delegate Identifier: 
+(10): ReSharper F# Function Identifier: 
+(11): ReSharper F# Function Identifier: 
+(12): ReSharper F# Delegate Identifier: 
+(13): ReSharper F# Function Identifier: 

--- a/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/identifierHighlighting/Delegates.fs
@@ -1,4 +1,0 @@
-module M
-
-type T1 = delegate of unit -> unit
-type T2 = delegate of int -> int

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Daemon/IdentifierHighlightingTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Daemon/IdentifierHighlightingTest.fs
@@ -21,7 +21,11 @@ type IdentifierHighlightingTest() =
 
     [<Test>] member x.``Active pattern decl``() = x.DoNamedTest()
 
-    [<Test>] member x.``Delegates``() = x.DoNamedTest()
+    [<TestReferences("System")>]
+    [<Test>] member x.``Delegates 01``() = x.DoNamedTest()
+    
+    [<TestReferences("System")>]
+    [<Test>] member x.``Delegates 02``() = x.DoNamedTest()
 
     [<Test>] member x.``Struct constructor``() = x.DoNamedTest()
 

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Daemon/IdentifierHighlightingTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Daemon/IdentifierHighlightingTest.fs
@@ -27,6 +27,9 @@ type IdentifierHighlightingTest() =
     [<TestReferences("System")>]
     [<Test>] member x.``Delegates 02``() = x.DoNamedTest()
 
+    [<TestReferences("System")>]
+    [<Test>] member x.``Delegates 03``() = x.DoNamedTest()
+    
     [<Test>] member x.``Struct constructor``() = x.DoNamedTest()
 
     [<Test>] member x.``op_RangeStep``() = x.DoNamedTest()


### PR DESCRIPTION
This PR adds delegate types highlighting.
Types like t = int -> int are now highlighted as delegates
Parameters with such types are now highlighted as functions
Parameters with other delegate signatures are still highlighted as values as they require Invoke(..) call
Before (Rider 2020.1):
![image](https://user-images.githubusercontent.com/37334640/85206389-7e77cc00-b32a-11ea-93e3-2d3e36101258.png)
After (Rider 2020.2 EAP):
![image](https://user-images.githubusercontent.com/37334640/85206396-92233280-b32a-11ea-9fef-be516aea69b6.png)
