### PR TITLE
Update to Gradle 6.6, Kotlin 1.4, RdGen 0.203.144

### DIFF
--- a/rider-fsharp/build.gradle.kts
+++ b/rider-fsharp/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.jetbrains.rd.generator.gradle.RdgenParams
+import com.jetbrains.rd.generator.gradle.RdGenExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.grammarkit.tasks.GenerateLexer
 import org.jetbrains.intellij.IntelliJPlugin
@@ -15,8 +15,9 @@ buildscript {
         maven { setUrl("https://cache-redirector.jetbrains.com/repo.maven.apache.org/maven2")}
     }
     dependencies {
-        classpath("com.jetbrains.rd:rd-gen:0.202.100")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
+        // https://www.myget.org/feed/rd-snapshots/package/maven/com.jetbrains.rd/rd-gen
+        classpath("com.jetbrains.rd:rd-gen:0.203.144")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.0")
     }
 }
 
@@ -136,7 +137,7 @@ fun File.writeTextIfChanged(content: String) {
     }
 }
 
-configure<RdgenParams> {
+configure<RdGenExtension> {
     val csOutput = File(repoRoot, "ReSharper.FSharp/src/FSharp.ProjectModelBase/src/Protocol")
     val ktOutput = File(repoRoot, "rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/protocol")
 

--- a/rider-fsharp/build.gradle.kts
+++ b/rider-fsharp/build.gradle.kts
@@ -16,7 +16,7 @@ buildscript {
     }
     dependencies {
         // https://www.myget.org/feed/rd-snapshots/package/maven/com.jetbrains.rd/rd-gen
-        classpath("com.jetbrains.rd:rd-gen:0.203.144")
+        classpath("com.jetbrains.rd:rd-gen:0.203.148")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.0")
     }
 }

--- a/rider-fsharp/gradle/wrapper/gradle-wrapper.properties
+++ b/rider-fsharp/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This is the last step of our long-time struggle with [Kotlin 1.4 migration](https://github.com/JetBrains/rd/pull/143). It will fix most of the tests currently failing in the plugin.