### PR TITLE
Generate idea-version during build

### DIFF
--- a/rider-fsharp/build.gradle.kts
+++ b/rider-fsharp/build.gradle.kts
@@ -75,7 +75,6 @@ intellij {
 
     instrumentCode = false
     downloadSources = false
-    updateSinceUntilBuild = false
 
     // Workaround for https://youtrack.jetbrains.com/issue/IDEA-179607
     setPlugins("rider-plugins-appender")


### PR DESCRIPTION
The `plugin.xml` file currently doesn't include `<idea-version … />` which is required for using the F# plugin as a dependency (e.g. to add F# support to another Rider plugin). If it is missing, the development version of the IDE used to build the plugin will fail to load the F# plugin.

Resetting the `updateSinceUntilBuild` back to its default value of `true` will add the element into the copy of the file used during build. The gradle scripts will set the current value of the Rider IJ platform as the `since-build` and will use a wildcard for the `until-build`, e.g.:

```xml
<idea-version since-build="203.5949" until-build="203.*" />
```