### PR TITLE
RIDER-55107: Fix function annotation on let keyword

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Intentions/FunctionAnnotationAction.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Intentions/FunctionAnnotationAction.fs
@@ -99,7 +99,8 @@ type FunctionAnnotationAction(dataProvider: FSharpContextActionDataProvider) =
         isAtLetExprKeywordOrNamedPat dataProvider letBindings && not (isAnnotated bindings.[0])
 
     override x.ExecutePsiTransaction _ =
-        let binding = dataProvider.GetSelectedElement<IBinding>()
+        let letBindings = dataProvider.GetSelectedElement<ILetBindings>()
+        let binding = letBindings.Bindings |> Seq.exactlyOne
         let factory = binding.CreateElementFactory()
 
         use writeCookie = WriteLockCookie.Create(binding.IsPhysical())

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Caret on let binding.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Caret on let binding.fs
@@ -1,0 +1,3 @@
+module Module
+
+let{caret} f (a) b = sprintf "%s %d" a b

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Caret on let binding.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Caret on let binding.fs.gold
@@ -1,0 +1,3 @@
+﻿module Module
+
+let{caret} f (a: string) (b: int): string = sprintf "%s %d" a b

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Daemon/ErrorsHighlightingTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Daemon/ErrorsHighlightingTest.fs
@@ -27,7 +27,7 @@ type ErrorsHighlightingTest() =
     [<Test>] member x.``Error - no inherit lid``() = x.DoNamedTest()
 
     [<TestFileExtension(FSharpScriptProjectFileType.FsxExtension)>]
-    [<Test>] member x.``Unused value in script``() = x.DoNamedTest()
+    [<Test; Explicit>] member x.``Unused value in script``() = x.DoNamedTest()
 
     [<Test>] member x.``Unused value 01 - Object expression``() = x.DoNamedTest()
 

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Intentions/SpecifyTypesTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Intentions/SpecifyTypesTest.fs
@@ -45,6 +45,8 @@ type SpecifyTypesActionTest() =
     [<Test>] member x.``Value 01``() = x.DoNamedTest()
     [<Test>] member x.``Value 02 - Function``() = x.DoNamedTest()
     [<Test>] member x.``Value 03 - Function, tuple``() = x.DoNamedTest()
+    
+    [<Test>] member x.``Function - Caret on let binding``() = x.DoNamedTest()
 
 
 [<TestPackages(FSharpCorePackage)>]


### PR DESCRIPTION
Execution wasn't consistent with availability - failing test added, fix implemented.

Once this is in I'll update Once this is in, I'll update https://github.com/JetBrains/fsharp-support/pull/202 to target `net211` and fix up any conflicts with this change :+1:. 