### PR TITLE
Initial draft of generating missing interface members for obj expressions

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Features/FSharp.Psi.Features.fsproj
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/FSharp.Psi.Features.fsproj
@@ -194,6 +194,7 @@
     <Compile Include="src\QuickFixes\GenerateInterfaceMembersFix.fs" />
     <Compile Include="src\QuickFixes\GenerateMissingOverridesFix.fs" />
     <Compile Include="src\QuickFixes\RemoveRedundantAttributeFix.fs" />
+    <Compile Include="src\QuickFixes\GenerateObjExprInterfaceMembersFix.fs" />
     <Compile Include="src\PostfixTemplates\PostfixTemplates.fs" />
     <Compile Include="src\PostfixTemplates\NotTemplate.fs" />
     <Compile Include="src\PostfixTemplates\LetPostfixTemplate.fs" />

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Highlightings/FSharpErrorUtil.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Highlightings/FSharpErrorUtil.fs
@@ -115,3 +115,11 @@ let getInterfaceImplHeaderRange (interfaceImpl: IInterfaceImplementation) =
         | withKeyword -> withKeyword :> ITreeNode
 
     getTreeNodesDocumentRange interfaceImpl.InterfaceKeyword last
+
+let getInterfaceImplOnObjExprHeaderRange (objExpr: IObjExpr) =
+    let last = 
+        match objExpr.WithKeyword with
+        | null -> objExpr.TypeName :> ITreeNode
+        | withKeyword -> withKeyword :> ITreeNode
+
+    getTreeNodesDocumentRange objExpr.NewKeyword last

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Highlightings/FcsErrors.xml
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Highlightings/FcsErrors.xml
@@ -273,6 +273,17 @@
     <QuickFix>GenerateInterfaceMembersFix</QuickFix>
   </Error>
 
+  <Error staticGroup="FSharpErrors" name="NoImplementationGivenInterfaceObjExpr">
+    <Parameter type="IObjExpr" name="impl"/>
+    <Parameter type="string" name="fcsMessage"/>
+    <Message value="{0}">
+      <Argument>fcsMessage</Argument>
+    </Message>
+    <Range>getInterfaceImplOnObjExprHeaderRange impl</Range>
+    <Behavour overlapResolvePolicy="NONE"/>
+    <QuickFix>GenerateObjExprInterfaceMembersFix</QuickFix>
+  </Error>
+
   <Error staticGroup="FSharpErrors" name="ReturnRequiresComputationExpression">
     <Parameter type="IYieldOrReturnExpr" name="yieldExpr"/>
     <Message value="`return` may only be used within computation expressions"/>

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/QuickFixes/GenerateObjExprInterfaceMembersFix.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/QuickFixes/GenerateObjExprInterfaceMembersFix.fs
@@ -1,0 +1,111 @@
+﻿namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.QuickFixes
+
+open System.Collections.Generic
+open FSharp.Compiler.SourceCodeServices
+open JetBrains.ReSharper.Plugins.FSharp.Psi
+open JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.Highlightings
+open JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.QuickFixes
+open JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Generate
+open JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Tree
+open JetBrains.ReSharper.Plugins.FSharp.Psi.Parsing
+open JetBrains.ReSharper.Plugins.FSharp.Psi.Tree
+open JetBrains.ReSharper.Plugins.FSharp.Psi.Util
+open JetBrains.ReSharper.Plugins.FSharp.Util
+open JetBrains.ReSharper.Psi
+open JetBrains.ReSharper.Psi.ExtensionsAPI
+open JetBrains.ReSharper.Psi.ExtensionsAPI.Tree
+open JetBrains.ReSharper.Resources.Shell
+
+type GenerateObjExprInterfaceMembersFix(error: NoImplementationGivenInterfaceObjExprError) =
+    inherit FSharpQuickFixBase()
+
+    let impl = error.Impl
+
+    // TODO: Reduce duplication by coming up with a common interface for TypeName, MemberDeclarations, FcsEntity
+    let getInterfaces (fcsType: FSharpType) =
+        fcsType.AllInterfaces
+        |> Seq.filter (fun t -> t.HasTypeDefinition)
+        |> Seq.map FcsEntityInstance.create
+        |> Seq.toList
+
+    override x.Text = "Generate missing members"
+
+    override x.IsAvailable _ =
+        let fcsEntity = impl.FcsEntity
+        isNotNull fcsEntity && fcsEntity.IsInterface 
+
+    override x.ExecutePsiTransaction _ =
+        use writeCookie = WriteLockCookie.Create(impl.IsPhysical())
+        use disableFormatter = new DisableCodeFormatter()
+
+        let interfaceType =
+            let typeDeclaration = impl.TypeName.Reference
+
+            let fcsEntity = typeDeclaration.GetFSharpSymbol() :?> FSharpEntity
+            fcsEntity.AllInterfaces |> Seq.find (fun e ->
+                e.HasTypeDefinition && e.TypeDefinition.IsEffectivelySameAs(impl.FcsEntity))
+
+        let displayContext = impl.TypeName.Reference.GetSymbolUse().DisplayContext
+
+        let existingMemberDecls = impl.MemberDeclarations
+
+        let implementedMembers =
+            existingMemberDecls
+            |> Seq.map (fun m ->
+                m.DeclaredElement.As<IOverridableMember>().ExplicitImplementations
+                |> Seq.choose (fun i -> i.Resolve() |> Option.ofObj |> Option.map (fun i -> i.Element.XMLDocId)))
+            |> Seq.concat
+            |> HashSet
+
+        let allInterfaceMembers = 
+            getInterfaces interfaceType |> List.collect (fun fcsEntityInstance ->
+                fcsEntityInstance.Entity.MembersFunctionsAndValues
+                |> Seq.map (fun mfv -> FcsMfvInstance.create mfv displayContext fcsEntityInstance.Substitution)
+                |> Seq.toList)
+
+        let needsTypesAnnotations =
+            GenerateOverrides.getMembersNeedingTypeAnnotations allInterfaceMembers
+
+        let membersToGenerate = 
+            allInterfaceMembers
+            |> List.filter (fun mfvInstance ->
+                not (mfvInstance.Mfv.IsAccessor()) &&
+
+                let xmlDocId = FSharpElementsUtil.GetXmlDocId(mfvInstance.Mfv)
+                not (implementedMembers.Contains(xmlDocId)))
+            |> List.sortBy (fun mfvInstance -> mfvInstance.Mfv.LogicalName) // todo: better sorting?
+            |> List.map (fun mfvInstance -> mfvInstance, needsTypesAnnotations.Contains(mfvInstance.Mfv))
+            |> List.map FSharpGeneratorMfvElement
+
+        let indent =
+            if existingMemberDecls.IsEmpty then
+                impl.Indent + impl.GetIndentSize()
+            else
+                existingMemberDecls.Last().Indent
+
+        let generatedMembers =
+            membersToGenerate
+            |> List.map (GenerateOverrides.generateMember impl indent)
+            |> List.collect (withNewLineAndIndentBefore indent)
+
+        let memberDeclarationList = impl.MemberDeclarationsList
+        if isNotNull memberDeclarationList then
+            let anchor = GenerateOverrides.addEmptyLineIfNeeded memberDeclarationList.LastChild
+            addNodesAfter anchor generatedMembers |> ignore
+        else
+            if isNull impl.WithKeyword then
+                addNodesAfter impl.TypeName [
+                    Whitespace()
+                    FSharpTokenType.WITH.CreateLeafElement()
+                ] |> ignore
+
+            addNodesAfter impl.WithKeyword [
+                NewLine(impl.GetLineEnding())
+                Whitespace(indent)
+                ElementType.MEMBER_DECLARATION_LIST.Create()
+            ] |> ignore
+
+            let memberDeclList = impl.MemberDeclarationsList
+            ModificationUtil.AddChild(memberDeclList, Whitespace()) |> ignore
+            addNodesAfter memberDeclList.FirstChild generatedMembers |> ignore
+            deleteChildRange memberDeclList.FirstChild memberDeclList.TypeMembers.[0].PrevSibling

--- a/ReSharper.FSharp/src/FSharp.Psi/src/FSharp.psi
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/FSharp.psi
@@ -643,7 +643,7 @@ objExpr options { stubBase="FSharpTypeElementDeclarationBase"; } extras {
   get { methodName="InterfaceMembers" path=<objExpr:INTERFACE_IMPL/interfaceImplementation:MEMBER_LIST/memberDeclarationList:MEMBER_DECL> };
 }:
   LBRACE
-  NEW
+  NEW<NEW, NewKeyword>
   typeReferenceName<TYPE_REFERENCE, TypeName>
   fSharpExpression<ARG_EXPR, ArgExpression>
   WITH<WITH, WithKeyword>

--- a/ReSharper.FSharp/src/FSharp.Psi/src/Impl/Tree/ObjExpr.cs
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/Impl/Tree/ObjExpr.cs
@@ -1,3 +1,4 @@
+using FSharp.Compiler.SourceCodeServices;
 using JetBrains.ReSharper.Plugins.FSharp.Psi.Tree;
 using JetBrains.ReSharper.Plugins.FSharp.Psi.Util;
 using JetBrains.ReSharper.Psi;
@@ -22,5 +23,8 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Tree
     public IType Type() => this.GetExpressionTypeFromFcs();
     public IExpressionType GetExpressionType() => Type();
     public IType GetImplicitlyConvertedTo() => Type();
+
+
+    public FSharpEntity FcsEntity => TypeName?.Reference.GetFSharpSymbol() as FSharpEntity;
   }
 }

--- a/ReSharper.FSharp/src/FSharp.Psi/src/Tree/IObjExpr.cs
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/Tree/IObjExpr.cs
@@ -1,6 +1,10 @@
+using FSharp.Compiler.SourceCodeServices;
+using JetBrains.Annotations;
+
 namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Tree
 {
   public partial interface IObjExpr : IFSharpTypeElementDeclaration
   {
+    [CanBeNull] FSharpEntity FcsEntity { get; }
   }
 }

--- a/ReSharper.FSharp/test/data/features/quickFixes/generateObjExprMembers/Partially complete implementation.fs
+++ b/ReSharper.FSharp/test/data/features/quickFixes/generateObjExprMembers/Partially complete implementation.fs
@@ -1,0 +1,9 @@
+module Module
+
+type I =
+  abstract P1: int
+  abstract P2: int
+  abstract P3: int
+
+let foo = { new I{caret} with
+            member this.P1 = failwith "todo" }

--- a/ReSharper.FSharp/test/data/features/quickFixes/generateObjExprMembers/Partially complete implementation.fs.gold
+++ b/ReSharper.FSharp/test/data/features/quickFixes/generateObjExprMembers/Partially complete implementation.fs.gold
@@ -1,0 +1,11 @@
+﻿module Module
+
+type I =
+  abstract P1: int
+  abstract P2: int
+  abstract P3: int
+
+let foo = { new I{caret} with
+            member this.P1 = failwith "todo"
+                   member this.P2 = failwith "todo"
+                   member this.P3 = failwith "todo" }

--- a/ReSharper.FSharp/test/data/features/quickFixes/generateObjExprMembers/Simple interface 01.fs
+++ b/ReSharper.FSharp/test/data/features/quickFixes/generateObjExprMembers/Simple interface 01.fs
@@ -1,0 +1,3 @@
+module Module
+
+let foo = { new System.IDisposable{caret} with }

--- a/ReSharper.FSharp/test/data/features/quickFixes/generateObjExprMembers/Simple interface 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/quickFixes/generateObjExprMembers/Simple interface 01.fs.gold
@@ -1,0 +1,4 @@
+﻿module Module
+
+let foo = { new System.IDisposable{caret} with
+            member this.Dispose() = failwith "todo" }

--- a/ReSharper.FSharp/test/data/features/quickFixes/generateObjExprMembers/Simple interface 02 - missing with.fs
+++ b/ReSharper.FSharp/test/data/features/quickFixes/generateObjExprMembers/Simple interface 02 - missing with.fs
@@ -1,0 +1,3 @@
+module Module
+
+let foo = { new System.IDisposable{caret} }

--- a/ReSharper.FSharp/test/data/features/quickFixes/generateObjExprMembers/Simple interface 02 - missing with.fs.gold
+++ b/ReSharper.FSharp/test/data/features/quickFixes/generateObjExprMembers/Simple interface 02 - missing with.fs.gold
@@ -1,0 +1,4 @@
+﻿module Module
+
+let foo = { new System.IDisposable with
+            member this.Dispose() = failwith "todo"{caret} }

--- a/ReSharper.FSharp/test/src/FSharp.Tests/FSharp.Tests.fsproj
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/FSharp.Tests.fsproj
@@ -90,6 +90,7 @@
     <Compile Include="QuickFixes\ReplaceLambdaBodyWithIdTest.fs" />
     <Compile Include="QuickFixes\GenerateInterfaceMembersFixTest.fs" />
     <Compile Include="QuickFixes\RemoveRedundantAttributeTest.fs" />
+    <Compile Include="QuickFixes\GenerateObjExprInterfaceMembersFixTest.fs" />
     <Compile Include="Intentions\IntentionsTestBase.fs" />
     <Compile Include="Intentions\ToRecursiveLetBindings.fs" />
     <Compile Include="Intentions\ToMultilineRecordTest.fs" />

--- a/ReSharper.FSharp/test/src/FSharp.Tests/QuickFixes/GenerateObjExprInterfaceMembersFixTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/QuickFixes/GenerateObjExprInterfaceMembersFixTest.fs
@@ -1,0 +1,15 @@
+﻿namespace JetBrains.ReSharper.Plugins.FSharp.Tests.Features
+
+open JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.QuickFixes
+open JetBrains.ReSharper.Plugins.FSharp.Tests
+open JetBrains.ReSharper.Plugins.FSharp.Tests.Features
+open NUnit.Framework
+
+type GenerateObjInterfaceMembersFixTest() =
+    inherit FSharpQuickFixTestBase<GenerateObjExprInterfaceMembersFix>()
+
+    override x.RelativeTestDataPath = "features/quickFixes/generateObjExprMembers"
+    
+    [<Test>] member x.``Simple interface 01``() = x.DoNamedTest()
+    [<Test>] member x.``Simple interface 02 - missing with``() = x.DoNamedTest()
+    [<Test>] member x.``Partially complete implementation``() = x.DoNamedTest()


### PR DESCRIPTION
Very much in an early state - currently copy-pasting the standard interface implementation, and will make that common shortly.

Looks like the easiest way to do that is to create an interface in the psi - will mark the PR as ready once I've done that.