### PR TITLE
Allow prohibiting getting type checks via thread-specific cookie

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Common/src/Checker/FSharpCheckerExtensions.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/Checker/FSharpCheckerExtensions.fs
@@ -19,7 +19,7 @@ type CheckResults =
     | StillRunning of Task<(FSharpParseFileResults * FSharpCheckFileResults) option>
 
 type FSharpChecker with
-    member x.ParseAndCheckDocument(path, source: ISourceText, options, allowStale: bool, opName) =
+    member internal x.ParseAndCheckDocument(path, source: ISourceText, options, allowStale: bool, opName) =
         let version = source.GetHashCode()
 
         let parseAndCheckFile =

--- a/ReSharper.FSharp/src/FSharp.Common/src/Checker/FSharpCheckerService.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/Checker/FSharpCheckerService.fs
@@ -92,6 +92,8 @@ type FSharpCheckerService
 
     member x.ParseAndCheckFile([<NotNull>] file: IPsiSourceFile, opName,
                                [<Optional; DefaultParameterValue(false)>] allowStaleResults) =
+        ProhibitTypeCheckCookie.AssertTypeCheckIsAllowed()
+
         match x.FcsProjectProvider.GetProjectOptions(file) with
         | None -> None
         | Some options ->

--- a/ReSharper.FSharp/src/FSharp.ProjectModelBase/src/ProhibitTypeCheckCookie.cs
+++ b/ReSharper.FSharp/src/FSharp.ProjectModelBase/src/ProhibitTypeCheckCookie.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Diagnostics;
+using JetBrains.Diagnostics;
+
+namespace JetBrains.ReSharper.Plugins.FSharp
+{
+  public struct ProhibitTypeCheckCookie : IDisposable
+  {
+    [ThreadStatic] private static bool IsAcquired;
+
+    /// Prohibits type checking on the current thread.
+    public static IDisposable Create()
+    {
+      AssertTypeCheckIsAllowed();
+
+      IsAcquired = true;
+      return new ProhibitTypeCheckCookie();
+    }
+
+    public void Dispose() => IsAcquired = false;
+
+    [Conditional("JET_MODE_ASSERT")]
+    public static void AssertTypeCheckIsAllowed()
+    {
+      Assertion.Assert(!IsAcquired, "!IsAcquired");
+    }
+  }
+}

--- a/ReSharper.FSharp/src/FSharp.ProjectModelBase/src/ProhibitTypeCheckCookie.cs
+++ b/ReSharper.FSharp/src/FSharp.ProjectModelBase/src/ProhibitTypeCheckCookie.cs
@@ -20,9 +20,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp
     public void Dispose() => IsAcquired = false;
 
     [Conditional("JET_MODE_ASSERT")]
-    public static void AssertTypeCheckIsAllowed()
-    {
+    public static void AssertTypeCheckIsAllowed() =>
       Assertion.Assert(!IsAcquired, "!IsAcquired");
-    }
   }
 }

--- a/ReSharper.FSharp/src/FSharp.Psi/src/Impl/Cache2/FSharpCacheProvider.cs
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/Impl/Cache2/FSharpCacheProvider.cs
@@ -21,6 +21,8 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Cache2
 
     public void BuildCache(IFile file, ICacheBuilder builder)
     {
+      using var cookie = ProhibitTypeCheckCookie.Create();
+
       var sourceFile = file.GetSourceFile();
       Assertion.AssertNotNull(sourceFile, "sourceFile != null");
 


### PR DESCRIPTION
Adds thread-specific cookie to prohibit type checks in critical sections and uses it when creating symbol cache parts.
Makes `FSharpCheckerService.ParseAndCheckFile` the only available API to get type check results in Psi/Psi.Features. Makes this API assert that type checks are allowed.