### PR TITLE
Use OwnerMember.SourceName in accessor's DeclaredElementName

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi/src/Impl/Tree/AccessorDeclaration.cs
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/Impl/Tree/AccessorDeclaration.cs
@@ -10,7 +10,8 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Tree
   internal partial class AccessorDeclaration
   {
     public override IFSharpIdentifierLikeNode NameIdentifier => (IFSharpIdentifierLikeNode) Identifier;
-    protected override string DeclaredElementName => Identifier.GetSourceName() + "_" + OwnerMember.CompiledName;
+    // We refer to OwnerMember.SourceName because the CompiledName Attribute does not apply to accessor's CompiledName
+    protected override string DeclaredElementName => Identifier.GetSourceName() + "_" + OwnerMember.SourceName;
     public override string CompiledName => DeclaredElementName;
     public override string SourceName => DeclaredElementName;
 

--- a/ReSharper.FSharp/test/data/cache/csharpResolve/Properties 18 - Explicit accessors - Compiled name.cs
+++ b/ReSharper.FSharp/test/data/cache/csharpResolve/Properties 18 - Explicit accessors - Compiled name.cs
@@ -6,5 +6,7 @@ public class Class1
  
     var _ = t.get_A(0);
     var __ = t.get_A1(0);
+    var ___ = t.A;
+    var ____ = t.A1;
   }
 }

--- a/ReSharper.FSharp/test/data/cache/csharpResolve/Properties 18 - Explicit accessors - Compiled name.cs
+++ b/ReSharper.FSharp/test/data/cache/csharpResolve/Properties 18 - Explicit accessors - Compiled name.cs
@@ -1,0 +1,10 @@
+public class Class1
+{
+  public Class1()
+  {
+    var t = new T();
+ 
+    var _ = t.get_A(0);
+    var __ = t.get_A1(0);
+  }
+}

--- a/ReSharper.FSharp/test/data/cache/csharpResolve/Properties 18 - Explicit accessors - Compiled name.fs
+++ b/ReSharper.FSharp/test/data/cache/csharpResolve/Properties 18 - Explicit accessors - Compiled name.fs
@@ -1,0 +1,5 @@
+namespace global
+
+type T() =
+    [<CompiledName "A1">]
+    member x.A with get(_: int) = 1

--- a/ReSharper.FSharp/test/data/cache/csharpResolve/Properties 18 - Explicit accessors - Compiled name.gold
+++ b/ReSharper.FSharp/test/data/cache/csharpResolve/Properties 18 - Explicit accessors - Compiled name.gold
@@ -6,11 +6,16 @@ public class Class1
  
     var _ = t.get_A(0);
     var __ = t.|get_A1|(0)(0);
+    var ___ = t.|A|(1);
+    var ____ = t.|A1|(2);
   }
 }
 
 ---------------------------------------------------------
 (0): ReSharper Error Highlighting: Cannot resolve symbol 'get_A1'
+(1): ReSharper Error Highlighting: Cannot resolve symbol 'A'
+(2): ReSharper Underlined Error Highlighting: Cannot access private property 'A1' here
 M:T.#ctor
 M:T.get_A(System.Int32)
 M:T.get_A(System.Int32)
+P:T.A1

--- a/ReSharper.FSharp/test/data/cache/csharpResolve/Properties 18 - Explicit accessors - Compiled name.gold
+++ b/ReSharper.FSharp/test/data/cache/csharpResolve/Properties 18 - Explicit accessors - Compiled name.gold
@@ -1,0 +1,16 @@
+public class Class1
+{
+  public Class1()
+  {
+    var t = new T();
+ 
+    var _ = t.get_A(0);
+    var __ = t.|get_A1|(0)(0);
+  }
+}
+
+---------------------------------------------------------
+(0): ReSharper Error Highlighting: Cannot resolve symbol 'get_A1'
+M:T.#ctor
+M:T.get_A(System.Int32)
+M:T.get_A(System.Int32)

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Cache/CSharpResolveTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Cache/CSharpResolveTest.fs
@@ -102,6 +102,7 @@ type CSharpResolveTest() =
     [<Test; Explicit>] member x.``Properties 15 - Indexer - Static``() = x.DoNamedTest()
     [<Test>] member x.``Properties 16 - Indexers - Partial accessors``() = x.DoNamedTest()
     [<Test>] member x.``Properties 17 - Indexers - Compiled name``() = x.DoNamedTest()
+    [<Test>] member x.``Properties 18 - Explicit accessors - Compiled name``() = x.DoNamedTest()
 
     [<Test>] member x.``Module bindings 01 - Simple``() = x.DoNamedTest()
     [<Test>] member x.``Module bindings 02 - Records``() = x.DoNamedTest()


### PR DESCRIPTION
We should refer to OwnerMember.SourceName because the CompiledName Attribute does not apply to accessor's CompiledName
![image](https://user-images.githubusercontent.com/26364714/102934001-60934b80-44b4-11eb-9289-530fa5c1e426.png)
