### PR TITLE
Fix for API change (ITypeMember.ContainingType)

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/QuickFixes/ReplaceWithWildPatFix.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/QuickFixes/ReplaceWithWildPatFix.fs
@@ -2,8 +2,8 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.QuickFixes
 
 open JetBrains.ReSharper.Feature.Services.Intentions.Scoped
 open JetBrains.ReSharper.Feature.Services.Intentions.Scoped.Actions
-open JetBrains.ReSharper.Feature.Services.Intentions.Scoped.QuickFixes
 open JetBrains.ReSharper.Feature.Services.Intentions.Scoped.Scopes
+open JetBrains.ReSharper.Feature.Services.QuickFixes.Scoped
 open JetBrains.ReSharper.Plugins.FSharp.Psi
 open JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.Highlightings
 open JetBrains.ReSharper.Plugins.FSharp.Psi.Impl

--- a/ReSharper.FSharp/src/FSharp.Psi/src/Impl/Cache2/Parts/FSharpGeneratedMethodBase.cs
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/Impl/Cache2/Parts/FSharpGeneratedMethodBase.cs
@@ -10,22 +10,20 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Cache2.Parts
 {
   public abstract class FSharpGeneratedMethodFromTypeBase : FSharpGeneratedMethodBase
   {
-    protected FSharpGeneratedMethodFromTypeBase([NotNull] ITypeElement containingType) =>
-      ContainingType = containingType;
+    [NotNull] private readonly ITypeElement myContainingType;
 
-    protected override ITypeElement ContainingType { get; }
+    protected FSharpGeneratedMethodFromTypeBase([NotNull] ITypeElement containingType) =>
+      myContainingType = containingType;
+
+    public override ITypeElement GetContainingType() => myContainingType;
   }
 
   public abstract class FSharpGeneratedMethodBase : FSharpGeneratedFunctionBase, IMethod
   {
-    [NotNull] protected abstract ITypeElement ContainingType { get; }
-
     protected override IClrDeclaredElement ContainingElement => ContainingType;
 
     protected IType ContainingTypeType =>
       ContainingType.WithIdSubstitution();
-
-    public override ITypeElement GetContainingType() => ContainingType;
     public override ITypeMember GetContainingTypeMember() => ContainingType as ITypeMember;
 
     public override DeclaredElementType GetElementType() =>

--- a/ReSharper.FSharp/src/FSharp.Psi/src/Impl/DeclaredElement/CompilerGenerated/FSharpGeneratedMemberBase.cs
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/Impl/DeclaredElement/CompilerGenerated/FSharpGeneratedMemberBase.cs
@@ -34,6 +34,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.DeclaredElement.CompilerGe
     public IList<IExplicitImplementation> ExplicitImplementations => EmptyList<IExplicitImplementation>.Instance;
 
     public Hash? CalcHash() => null;
+    public ITypeElement ContainingType => GetContainingType();
 
     public AccessibilityDomain AccessibilityDomain =>
       new AccessibilityDomain(AccessibilityDomain.AccessibilityDomainType.PUBLIC, null);

--- a/ReSharper.FSharp/src/FSharp.Psi/src/Impl/DeclaredElement/CompilerGenerated/FSharpGeneratedPropertyBase.cs
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/Impl/DeclaredElement/CompilerGenerated/FSharpGeneratedPropertyBase.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using JetBrains.Annotations;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Impl.Special;
 using JetBrains.ReSharper.Psi.Resolve;
@@ -10,19 +9,18 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.DeclaredElement.CompilerGe
 {
   public abstract class FSharpGeneratedPropertyFromTypeBase : FSharpGeneratedPropertyBase
   {
-    protected FSharpGeneratedPropertyFromTypeBase(ITypeElement typeElement) =>
-      ContainingType = typeElement;
+    private readonly ITypeElement myContainingType;
 
-    public override ITypeElement ContainingType { get; }
+    protected FSharpGeneratedPropertyFromTypeBase(ITypeElement containingType) =>
+      myContainingType = containingType;
+
+    public override ITypeElement GetContainingType() => myContainingType;
   }
 
   public abstract class FSharpGeneratedPropertyBase : FSharpGeneratedMemberBase, IProperty
   {
     protected override IClrDeclaredElement ContainingElement => ContainingType;
-    public override ITypeElement GetContainingType() => ContainingType;
     public override ITypeMember GetContainingTypeMember() => (ITypeMember) ContainingType;
-
-    [NotNull] public abstract ITypeElement ContainingType { get; }
 
     public abstract IType Type { get; }
 

--- a/ReSharper.FSharp/src/FSharp.Psi/src/Impl/DeclaredElement/CompilerGenerated/FSharpUnionCaseIsCaseProperty.cs
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/Impl/DeclaredElement/CompilerGenerated/FSharpUnionCaseIsCaseProperty.cs
@@ -13,7 +13,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.DeclaredElement.CompilerGe
     internal FSharpUnionCaseIsCaseProperty([NotNull] IUnionCase unionCase) =>
       UnionCase = unionCase;
 
-    public override ITypeElement ContainingType => UnionCase.GetContainingType();
+    public override ITypeElement GetContainingType() => UnionCase.GetContainingType();
     public IClrDeclaredElement OriginElement => UnionCase;
 
     public IDeclaredElementPointer<IFSharpGeneratedFromOtherElement> CreatePointer() =>

--- a/ReSharper.FSharp/src/FSharp.Psi/src/Impl/DeclaredElement/CompilerGenerated/FSharpUnionCaseNewMethod.cs
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/Impl/DeclaredElement/CompilerGenerated/FSharpUnionCaseNewMethod.cs
@@ -14,7 +14,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.DeclaredElement.CompilerGe
     public FSharpUnionCaseNewMethod([NotNull] IUnionCase unionCase) =>
       UnionCase = unionCase;
 
-    protected override ITypeElement ContainingType => UnionCase.GetContainingType();
+    public override ITypeElement GetContainingType() => UnionCase.GetContainingType();
     public IClrDeclaredElement OriginElement => UnionCase;
 
     public IDeclaredElementPointer<IFSharpGeneratedFromOtherElement> CreatePointer() =>


### PR DESCRIPTION
P.S. 
Also unified the ContainingType declaration through GetContainingType to avoid potential recursive calls in the inheritance hierarchy