### PR TITLE
Add Rider self debug configurations for the backend solution

### DIFF
--- a/ReSharper.FSharp/.idea/.idea.ReSharper.FSharp/.idea/runConfigurations/Rider_Debug__Unix_.xml
+++ b/ReSharper.FSharp/.idea/.idea.ReSharper.FSharp/.idea/runConfigurations/Rider_Debug__Unix_.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Rider Debug (Unix)" type="RunExe" factoryName=".NET Executable">
+    <option name="EXE_PATH" value="$PROJECT_DIR$/../rider-fsharp/gradlew" />
+    <option name="PROGRAM_PARAMETERS" value="runIde" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/../rider-fsharp" />
+    <option name="PASS_PARENT_ENVS" value="1" />
+    <envs>
+      <env name="RESHARPER_HOST_DEBUG_SELF" value="1" />
+    </envs>
+    <option name="USE_EXTERNAL_CONSOLE" value="0" />
+    <option name="USE_MONO" value="0" />
+    <option name="RUNTIME_ARGUMENTS" value="" />
+    <method v="2">
+      <option name="Build Solution" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/ReSharper.FSharp/.idea/.idea.ReSharper.FSharp/.idea/runConfigurations/Rider_Debug__Unix_.xml
+++ b/ReSharper.FSharp/.idea/.idea.ReSharper.FSharp/.idea/runConfigurations/Rider_Debug__Unix_.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Rider Debug (Unix)" type="RunExe" factoryName=".NET Executable">
+  <configuration default="false" name="Rider Debug (Unix)" type="RunNativeExe" factoryName="Native Executable">
     <option name="EXE_PATH" value="$PROJECT_DIR$/../rider-fsharp/gradlew" />
     <option name="PROGRAM_PARAMETERS" value="runIde" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/../rider-fsharp" />

--- a/ReSharper.FSharp/.idea/.idea.ReSharper.FSharp/.idea/runConfigurations/Rider_Debug__Win_.xml
+++ b/ReSharper.FSharp/.idea/.idea.ReSharper.FSharp/.idea/runConfigurations/Rider_Debug__Win_.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Rider Debug (Win)" type="RunExe" factoryName=".NET Executable">
+    <option name="EXE_PATH" value="$PROJECT_DIR$/../rider-fsharp/gradlew.bat" />
+    <option name="PROGRAM_PARAMETERS" value="runIde" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/../rider-fsharp" />
+    <option name="PASS_PARENT_ENVS" value="1" />
+    <envs>
+      <env name="RESHARPER_HOST_DEBUG_SELF" value="1" />
+    </envs>
+    <option name="USE_EXTERNAL_CONSOLE" value="0" />
+    <option name="USE_MONO" value="0" />
+    <option name="RUNTIME_ARGUMENTS" value="" />
+    <method v="2">
+      <option name="Build Solution" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
@auduchinok, could you check if it works on Mac, please?

Obviously, we could try to do better and create a single configuration for both Unix and Windows (in form of the combined sh/cmd script), but for start, let's check if it works at all :)

(I've tested that on Windows)