### PR TITLE
Escape newlines in tooltips

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Stages/FSharpIdentifierTooltipProvider.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Stages/FSharpIdentifierTooltipProvider.fs
@@ -83,10 +83,8 @@ type FSharpIdentifierTooltipProvider(lifetime, solution, presenter, xmlDocServic
             RichText.Empty
 
     let richTextEscapeNewLines (text: RichText) =
-        text.GetFormattedParts()
-        |> Seq.fold
-               (fun (result: RichText) (part: RichString) -> result.Append(part.Text.Replace("\n", "<br>")))
-               RichText.Empty
+        (RichText.Empty, text.GetFormattedParts()) ||> Seq.fold (fun result part ->
+            result.Append(part.Text.Replace("\n", "<br>")))
 
     let [<Literal>] opName = "FSharpIdentifierTooltipProvider"
 

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Stages/FSharpIdentifierTooltipProvider.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Stages/FSharpIdentifierTooltipProvider.fs
@@ -82,6 +82,12 @@ type FSharpIdentifierTooltipProvider(lifetime, solution, presenter, xmlDocServic
             (fun (result: RichText) part -> if result.IsEmpty then part else result + sep + part)
             RichText.Empty
 
+    let richTextEscapeNewLines (text: RichText) =
+        text.GetFormattedParts()
+        |> Seq.fold
+               (fun (result: RichText) (part: RichString) -> result.Append(part.Text.Replace("\n", "<br>")))
+               RichText.Empty
+
     let [<Literal>] opName = "FSharpIdentifierTooltipProvider"
 
     static member GetFSharpToolTipText(checkResults: FSharpCheckFileResults, token: IFSharpIdentifierToken) =
@@ -148,6 +154,7 @@ type FSharpIdentifierTooltipProvider(lifetime, solution, presenter, xmlDocServic
                       | _ -> () ]
                     |> richTextJoin "\n\n"))
         |> richTextJoin IdentifierTooltipProvider.RIDER_TOOLTIP_SEPARATOR
+        |> richTextEscapeNewLines
         |> RichTextBlock
 
     interface IFSharpIdentifierTooltipProvider


### PR DESCRIPTION
We need to do this on the F# side because if we do this on the Rider side we'd have to escape all of the tooltips, which would cause us to insert `<br>` tags inside CSS, which totally breaks a lot of tooltips