### PR TITLE
Frontend/Psi: avoid extra parsing events by wrapping content in an extra lazy container

### DIFF
--- a/rider-fsharp/parserTest/build.gradle.kts
+++ b/rider-fsharp/parserTest/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
   testImplementation(libs.junit)
   testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.9.2")
   testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.9.2")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")
   intellijPlatform {
     val dir = file("../build/rider")
     if (dir.exists()) {

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 01 - simple.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 01 - simple.txt
@@ -1,18 +1,19 @@
 FSharpFile
-  FSharpExpression
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"123"')
-    PsiElement(PLUS)('+')
-    PsiComment(BLOCK_COMMENT)('(*comment*)')
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"123"')
-  PsiWhiteSpace('\n')
-  PsiWhiteSpace('\n')
-  FSharpExpression
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"123"')
-    PsiComment(BLOCK_COMMENT)('(*comment*)')
-    PsiElement(PLUS)('+')
-    PsiWhiteSpace(' ')
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"123"')
+  PsiElement(DUMMY_CONTAINER)
+    FSharpExpression
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')
+      PsiElement(PLUS)('+')
+      PsiComment(BLOCK_COMMENT)('(*comment*)')
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')
+    PsiWhiteSpace('\n')
+    PsiWhiteSpace('\n')
+    FSharpExpression
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')
+      PsiComment(BLOCK_COMMENT)('(*comment*)')
+      PsiElement(PLUS)('+')
+      PsiWhiteSpace(' ')
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 02 - space before plus.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 02 - space before plus.txt
@@ -1,16 +1,17 @@
 FSharpFile
-  FSharpStringLiteralExpression
-    PsiElement(STRING)('"123"')
-  PsiWhiteSpace(' ')
-  PsiElement(PLUS)('+')
-  FSharpStringLiteralExpression
-    PsiElement(STRING)('"123"')
-  PsiWhiteSpace('\n')
-  PsiWhiteSpace('\n')
-  FSharpExpression
+  PsiElement(DUMMY_CONTAINER)
     FSharpStringLiteralExpression
       PsiElement(STRING)('"123"')
-    PsiElement(PLUS)('+')
     PsiWhiteSpace(' ')
+    PsiElement(PLUS)('+')
     FSharpStringLiteralExpression
       PsiElement(STRING)('"123"')
+    PsiWhiteSpace('\n')
+    PsiWhiteSpace('\n')
+    FSharpExpression
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')
+      PsiElement(PLUS)('+')
+      PsiWhiteSpace(' ')
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 03 - multiline.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 03 - multiline.txt
@@ -1,27 +1,28 @@
 FSharpFile
-  PsiElement(LET)('let')
-  PsiWhiteSpace(' ')
-  PsiElement(UNDERSCORE)('_')
-  PsiWhiteSpace(' ')
-  PsiElement(EQUALS)('=')
-  PsiWhiteSpace('\n')
-  PsiWhiteSpace('    ')
-  PsiElement(IDENT)('id')
-  PsiWhiteSpace(' ')
-  FSharpExpression
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"123"')
+  PsiElement(DUMMY_CONTAINER)
+    PsiElement(LET)('let')
     PsiWhiteSpace(' ')
-    PsiElement(PLUS)('+')
-    PsiWhiteSpace('\n')
-    PsiWhiteSpace('\n')
-    PsiWhiteSpace('       ')
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"123"')
-    PsiWhiteSpace('\n')
-    PsiWhiteSpace('\n')
-    PsiWhiteSpace('     ')
-    PsiElement(PLUS)('+')
+    PsiElement(UNDERSCORE)('_')
     PsiWhiteSpace(' ')
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"123"')
+    PsiElement(EQUALS)('=')
+    PsiWhiteSpace('\n')
+    PsiWhiteSpace('    ')
+    PsiElement(IDENT)('id')
+    PsiWhiteSpace(' ')
+    FSharpExpression
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')
+      PsiWhiteSpace(' ')
+      PsiElement(PLUS)('+')
+      PsiWhiteSpace('\n')
+      PsiWhiteSpace('\n')
+      PsiWhiteSpace('       ')
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')
+      PsiWhiteSpace('\n')
+      PsiWhiteSpace('\n')
+      PsiWhiteSpace('     ')
+      PsiElement(PLUS)('+')
+      PsiWhiteSpace(' ')
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 04 - multiline with wrong offset 01.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 04 - multiline with wrong offset 01.txt
@@ -1,19 +1,20 @@
 FSharpFile
-  PsiElement(LET)('let')
-  PsiWhiteSpace(' ')
-  PsiElement(UNDERSCORE)('_')
-  PsiWhiteSpace(' ')
-  PsiElement(EQUALS)('=')
-  PsiWhiteSpace('\n')
-  PsiWhiteSpace('     ')
-  PsiElement(IDENT)('id')
-  PsiWhiteSpace(' ')
-  FSharpExpression
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"123"')
-    PsiWhiteSpace('\n')
-    PsiWhiteSpace('  ')
-    PsiElement(PLUS)('+')
+  PsiElement(DUMMY_CONTAINER)
+    PsiElement(LET)('let')
     PsiWhiteSpace(' ')
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"123"')
+    PsiElement(UNDERSCORE)('_')
+    PsiWhiteSpace(' ')
+    PsiElement(EQUALS)('=')
+    PsiWhiteSpace('\n')
+    PsiWhiteSpace('     ')
+    PsiElement(IDENT)('id')
+    PsiWhiteSpace(' ')
+    FSharpExpression
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')
+      PsiWhiteSpace('\n')
+      PsiWhiteSpace('  ')
+      PsiElement(PLUS)('+')
+      PsiWhiteSpace(' ')
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 04 - multiline with wrong offset 02.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 04 - multiline with wrong offset 02.txt
@@ -1,17 +1,18 @@
 FSharpFile
-  PsiElement(LET)('let')
-  PsiWhiteSpace(' ')
-  PsiElement(UNDERSCORE)('_')
-  PsiWhiteSpace(' ')
-  PsiElement(EQUALS)('=')
-  PsiWhiteSpace('\n')
-  PsiWhiteSpace('     ')
-  FSharpExpression
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"123"')
+  PsiElement(DUMMY_CONTAINER)
+    PsiElement(LET)('let')
+    PsiWhiteSpace(' ')
+    PsiElement(UNDERSCORE)('_')
+    PsiWhiteSpace(' ')
+    PsiElement(EQUALS)('=')
     PsiWhiteSpace('\n')
-    PsiWhiteSpace('  ')
-    PsiElement(PLUS)('+')
-    PsiWhiteSpace('  ')
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"123"')
+    PsiWhiteSpace('     ')
+    FSharpExpression
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')
+      PsiWhiteSpace('\n')
+      PsiWhiteSpace('  ')
+      PsiElement(PLUS)('+')
+      PsiWhiteSpace('  ')
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 05 - with ident.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 05 - with ident.txt
@@ -1,17 +1,18 @@
 FSharpFile
-  FSharpExpression
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"123"')
-    PsiWhiteSpace(' ')
-    PsiElement(PLUS)('+')
-    PsiWhiteSpace(' ')
-    PsiElement(IDENT)('x')
-    PsiWhiteSpace(' ')
-    PsiElement(PLUS)('+')
-    PsiWhiteSpace(' ')
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"123"')
-    PsiWhiteSpace(' ')
-    PsiElement(PLUS)('+')
-    PsiWhiteSpace(' ')
-    PsiElement(IDENT)('y')
+  PsiElement(DUMMY_CONTAINER)
+    FSharpExpression
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')
+      PsiWhiteSpace(' ')
+      PsiElement(PLUS)('+')
+      PsiWhiteSpace(' ')
+      PsiElement(IDENT)('x')
+      PsiWhiteSpace(' ')
+      PsiElement(PLUS)('+')
+      PsiWhiteSpace(' ')
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')
+      PsiWhiteSpace(' ')
+      PsiElement(PLUS)('+')
+      PsiWhiteSpace(' ')
+      PsiElement(IDENT)('y')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 06 - unfinished.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 06 - unfinished.txt
@@ -1,5 +1,6 @@
 FSharpFile
-  FSharpStringLiteralExpression
-    PsiElement(STRING)('"123"')
-  PsiWhiteSpace(' ')
-  PsiElement(PLUS)('+')
+  PsiElement(DUMMY_CONTAINER)
+    FSharpStringLiteralExpression
+      PsiElement(STRING)('"123"')
+    PsiWhiteSpace(' ')
+    PsiElement(PLUS)('+')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 07 - multiline string.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 07 - multiline string.txt
@@ -1,15 +1,16 @@
 FSharpFile
-  PsiElement(LET)('let')
-  PsiWhiteSpace(' ')
-  PsiElement(UNDERSCORE)('_')
-  PsiWhiteSpace(' ')
-  PsiElement(EQUALS)('=')
-  PsiWhiteSpace(' ')
-  FSharpExpression
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"\n\n123"')
-    PsiWhiteSpace('  ')
-    PsiElement(PLUS)('+')
+  PsiElement(DUMMY_CONTAINER)
+    PsiElement(LET)('let')
     PsiWhiteSpace(' ')
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"123"')
+    PsiElement(UNDERSCORE)('_')
+    PsiWhiteSpace(' ')
+    PsiElement(EQUALS)('=')
+    PsiWhiteSpace(' ')
+    FSharpExpression
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"\n\n123"')
+      PsiWhiteSpace('  ')
+      PsiElement(PLUS)('+')
+      PsiWhiteSpace(' ')
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 08 - multiline string with wrong offset.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 08 - multiline string with wrong offset.txt
@@ -1,15 +1,16 @@
 FSharpFile
-  PsiElement(LET)('let')
-  PsiWhiteSpace(' ')
-  PsiElement(UNDERSCORE)('_')
-  PsiWhiteSpace(' ')
-  PsiElement(EQUALS)('=')
-  PsiWhiteSpace(' ')
-  FSharpExpression
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"\n\n123"')
+  PsiElement(DUMMY_CONTAINER)
+    PsiElement(LET)('let')
     PsiWhiteSpace(' ')
-    PsiElement(PLUS)('+')
+    PsiElement(UNDERSCORE)('_')
     PsiWhiteSpace(' ')
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"123"')
+    PsiElement(EQUALS)('=')
+    PsiWhiteSpace(' ')
+    FSharpExpression
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"\n\n123"')
+      PsiWhiteSpace(' ')
+      PsiElement(PLUS)('+')
+      PsiWhiteSpace(' ')
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 09 - with interpolated.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 09 - with interpolated.txt
@@ -1,13 +1,14 @@
 FSharpFile
-  FSharpExpression
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('"123"')
-    PsiWhiteSpace(' ')
-    PsiElement(PLUS)('+')
-    PsiWhiteSpace(' ')
-    FSharpInterpolatedStringLiteralExpression
-      FSharpInterpolatedStringLiteralExpressionPart
-        PsiElement(REGULAR_INTERPOLATED_STRING_START)('$"1 {')
-      PsiElement(INT32)('2')
-      FSharpInterpolatedStringLiteralExpressionPart
-        PsiElement(REGULAR_INTERPOLATED_STRING_END)('} 3"')
+  PsiElement(DUMMY_CONTAINER)
+    FSharpExpression
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('"123"')
+      PsiWhiteSpace(' ')
+      PsiElement(PLUS)('+')
+      PsiWhiteSpace(' ')
+      FSharpInterpolatedStringLiteralExpression
+        FSharpInterpolatedStringLiteralExpressionPart
+          PsiElement(REGULAR_INTERPOLATED_STRING_START)('$"1 {')
+        PsiElement(INT32)('2')
+        FSharpInterpolatedStringLiteralExpressionPart
+          PsiElement(REGULAR_INTERPOLATED_STRING_END)('} 3"')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 10 - with expression.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/concatenation 10 - with expression.txt
@@ -1,14 +1,15 @@
 FSharpFile
-  FSharpStringLiteralExpression
-    PsiElement(STRING)('"123"')
-  PsiWhiteSpace(' ')
-  PsiElement(PLUS)('+')
-  PsiWhiteSpace(' ')
-  PsiElement(RESERVED_LITERAL_FORMATS)('2.ToString')
-  PsiElement(LPAREN)('(')
-  PsiElement(RPAREN)(')')
-  PsiWhiteSpace(' ')
-  PsiElement(PLUS)('+')
-  PsiWhiteSpace(' ')
-  FSharpStringLiteralExpression
-    PsiElement(STRING)('"456"')
+  PsiElement(DUMMY_CONTAINER)
+    FSharpStringLiteralExpression
+      PsiElement(STRING)('"123"')
+    PsiWhiteSpace(' ')
+    PsiElement(PLUS)('+')
+    PsiWhiteSpace(' ')
+    PsiElement(RESERVED_LITERAL_FORMATS)('2.ToString')
+    PsiElement(LPAREN)('(')
+    PsiElement(RPAREN)(')')
+    PsiWhiteSpace(' ')
+    PsiElement(PLUS)('+')
+    PsiWhiteSpace(' ')
+    FSharpStringLiteralExpression
+      PsiElement(STRING)('"456"')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/empty.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/empty.txt
@@ -1,2 +1,3 @@
 FSharpFile
-  <empty list>
+  PsiElement(DUMMY_CONTAINER)
+    <empty list>

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/interpolated strings 01.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/interpolated strings 01.txt
@@ -1,46 +1,47 @@
 FSharpFile
-  FSharpInterpolatedStringLiteralExpression
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(REGULAR_INTERPOLATED_STRING)('$"1"')
-  PsiWhiteSpace('\n')
-  PsiWhiteSpace('\n')
-  FSharpInterpolatedStringLiteralExpression
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(REGULAR_INTERPOLATED_STRING_START)('$"1 {')
-    PsiElement(INT32)('2')
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(REGULAR_INTERPOLATED_STRING_END)('} 3"')
-  PsiWhiteSpace('\n')
-  PsiWhiteSpace('\n')
-  FSharpInterpolatedStringLiteralExpression
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(VERBATIM_INTERPOLATED_STRING_START)('$@"1 {')
-    PsiElement(INT32)('2')
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(VERBATIM_INTERPOLATED_STRING_END)('} 3"')
-  PsiWhiteSpace('\n')
-  PsiWhiteSpace('\n')
-  FSharpInterpolatedStringLiteralExpression
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(VERBATIM_INTERPOLATED_STRING)('$@"1"')
-  PsiWhiteSpace('\n')
-  PsiWhiteSpace('\n')
-  FSharpInterpolatedStringLiteralExpression
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(TRIPLE_QUOTE_INTERPOLATED_STRING)('$"""1"""')
-  PsiWhiteSpace('\n')
-  PsiWhiteSpace('\n')
-  FSharpInterpolatedStringLiteralExpression
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(TRIPLE_QUOTE_INTERPOLATED_STRING_START)('$"""1 {')
-    PsiElement(INT32)('2')
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(TRIPLE_QUOTED_STRING_END)('} 3"""')
-  PsiWhiteSpace('\n')
-  PsiWhiteSpace('\n')
-  FSharpInterpolatedStringLiteralExpression
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(RAW_INTERPOLATED_STRING_START)('$$"""{1} {{')
-    PsiElement(INT32)('2')
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(RAW_INTERPOLATED_STRING_END)('}}"""')
+  PsiElement(DUMMY_CONTAINER)
+    FSharpInterpolatedStringLiteralExpression
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(REGULAR_INTERPOLATED_STRING)('$"1"')
+    PsiWhiteSpace('\n')
+    PsiWhiteSpace('\n')
+    FSharpInterpolatedStringLiteralExpression
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(REGULAR_INTERPOLATED_STRING_START)('$"1 {')
+      PsiElement(INT32)('2')
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(REGULAR_INTERPOLATED_STRING_END)('} 3"')
+    PsiWhiteSpace('\n')
+    PsiWhiteSpace('\n')
+    FSharpInterpolatedStringLiteralExpression
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(VERBATIM_INTERPOLATED_STRING_START)('$@"1 {')
+      PsiElement(INT32)('2')
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(VERBATIM_INTERPOLATED_STRING_END)('} 3"')
+    PsiWhiteSpace('\n')
+    PsiWhiteSpace('\n')
+    FSharpInterpolatedStringLiteralExpression
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(VERBATIM_INTERPOLATED_STRING)('$@"1"')
+    PsiWhiteSpace('\n')
+    PsiWhiteSpace('\n')
+    FSharpInterpolatedStringLiteralExpression
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(TRIPLE_QUOTE_INTERPOLATED_STRING)('$"""1"""')
+    PsiWhiteSpace('\n')
+    PsiWhiteSpace('\n')
+    FSharpInterpolatedStringLiteralExpression
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(TRIPLE_QUOTE_INTERPOLATED_STRING_START)('$"""1 {')
+      PsiElement(INT32)('2')
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(TRIPLE_QUOTED_STRING_END)('} 3"""')
+    PsiWhiteSpace('\n')
+    PsiWhiteSpace('\n')
+    FSharpInterpolatedStringLiteralExpression
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(RAW_INTERPOLATED_STRING_START)('$$"""{1} {{')
+      PsiElement(INT32)('2')
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(RAW_INTERPOLATED_STRING_END)('}}"""')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/interpolated strings 02 - unfinished.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/interpolated strings 02 - unfinished.txt
@@ -1,8 +1,9 @@
 FSharpFile
-  FSharpInterpolatedStringLiteralExpression
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(REGULAR_INTERPOLATED_STRING_START)('$"1 {')
-    PsiElement(INT32)('2')
-    PsiWhiteSpace('\n')
-    PsiWhiteSpace('\n')
-    PsiElement(INT32)('3')
+  PsiElement(DUMMY_CONTAINER)
+    FSharpInterpolatedStringLiteralExpression
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(REGULAR_INTERPOLATED_STRING_START)('$"1 {')
+      PsiElement(INT32)('2')
+      PsiWhiteSpace('\n')
+      PsiWhiteSpace('\n')
+      PsiElement(INT32)('3')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/regular strings 01.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/regular strings 01.txt
@@ -1,11 +1,12 @@
 FSharpFile
-  FSharpStringLiteralExpression
-    PsiElement(STRING)('"1"')
-  PsiWhiteSpace('\n')
-  PsiWhiteSpace('\n')
-  FSharpStringLiteralExpression
-    PsiElement(VERBATIM_STRING)('@"123"')
-  PsiWhiteSpace('\n')
-  PsiWhiteSpace('\n')
-  FSharpStringLiteralExpression
-    PsiElement(TRIPLE_QUOTED_STRING)('"""1"""')
+  PsiElement(DUMMY_CONTAINER)
+    FSharpStringLiteralExpression
+      PsiElement(STRING)('"1"')
+    PsiWhiteSpace('\n')
+    PsiWhiteSpace('\n')
+    FSharpStringLiteralExpression
+      PsiElement(VERBATIM_STRING)('@"123"')
+    PsiWhiteSpace('\n')
+    PsiWhiteSpace('\n')
+    FSharpStringLiteralExpression
+      PsiElement(TRIPLE_QUOTED_STRING)('"""1"""')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/regular strings 02 - unfinished.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/regular strings 02 - unfinished.txt
@@ -1,3 +1,4 @@
 FSharpFile
-  FSharpStringLiteralExpression
-    PsiElement(UNFINISHED_STRING)('"1 2\n\n3')
+  PsiElement(DUMMY_CONTAINER)
+    FSharpStringLiteralExpression
+      PsiElement(UNFINISHED_STRING)('"1 2\n\n3')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/unfinished 01 - regular.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/unfinished 01 - regular.txt
@@ -1,3 +1,4 @@
 FSharpFile
-  FSharpStringLiteralExpression
-    PsiElement(UNFINISHED_STRING)('"\n1')
+  PsiElement(DUMMY_CONTAINER)
+    FSharpStringLiteralExpression
+      PsiElement(UNFINISHED_STRING)('"\n1')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/unfinished 02 - interpolated 01.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/unfinished 02 - interpolated 01.txt
@@ -1,9 +1,10 @@
 FSharpFile
-  FSharpInterpolatedStringLiteralExpression
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(REGULAR_INTERPOLATED_STRING_START)('$" {')
-    PsiWhiteSpace('\n')
-    PsiElement(INT32)('1')
-    PsiWhiteSpace('\n')
-    FSharpStringLiteralExpression
-      PsiElement(UNFINISHED_STRING)('"\n\n1')
+  PsiElement(DUMMY_CONTAINER)
+    FSharpInterpolatedStringLiteralExpression
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(REGULAR_INTERPOLATED_STRING_START)('$" {')
+      PsiWhiteSpace('\n')
+      PsiElement(INT32)('1')
+      PsiWhiteSpace('\n')
+      FSharpStringLiteralExpression
+        PsiElement(UNFINISHED_STRING)('"\n\n1')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/unfinished 02 - interpolated 02.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/unfinished 02 - interpolated 02.txt
@@ -1,7 +1,8 @@
 FSharpFile
-  FSharpInterpolatedStringLiteralExpression
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(REGULAR_INTERPOLATED_STRING_START)('$" {')
-    PsiWhiteSpace(' ')
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(REGULAR_INTERPOLATED_STRING_MIDDLE)('}')
+  PsiElement(DUMMY_CONTAINER)
+    FSharpInterpolatedStringLiteralExpression
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(REGULAR_INTERPOLATED_STRING_START)('$" {')
+      PsiWhiteSpace(' ')
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(REGULAR_INTERPOLATED_STRING_MIDDLE)('}')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/unfinished 03 - interpolated in interpolated.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpDummyParserTests/unfinished 03 - interpolated in interpolated.txt
@@ -1,15 +1,16 @@
 FSharpFile
-  FSharpInterpolatedStringLiteralExpression
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(TRIPLE_QUOTE_INTERPOLATED_STRING_START)('$"""{')
-    PsiWhiteSpace(' ')
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(REGULAR_INTERPOLATED_STRING_START)('$"{')
-    PsiWhiteSpace(' ')
-    FSharpInterpolatedStringLiteralExpressionPart
-      PsiElement(REGULAR_INTERPOLATED_STRING_END)('}"')
-    FSharpStringLiteralExpression
-      PsiElement(STRING)('""')
-    PsiWhiteSpace('\n')
-    PsiWhiteSpace('\n')
-    PsiElement(INT32)('1')
+  PsiElement(DUMMY_CONTAINER)
+    FSharpInterpolatedStringLiteralExpression
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(TRIPLE_QUOTE_INTERPOLATED_STRING_START)('$"""{')
+      PsiWhiteSpace(' ')
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(REGULAR_INTERPOLATED_STRING_START)('$"{')
+      PsiWhiteSpace(' ')
+      FSharpInterpolatedStringLiteralExpressionPart
+        PsiElement(REGULAR_INTERPOLATED_STRING_END)('}"')
+      FSharpStringLiteralExpression
+        PsiElement(STRING)('""')
+      PsiWhiteSpace('\n')
+      PsiWhiteSpace('\n')
+      PsiElement(INT32)('1')

--- a/rider-fsharp/parserTest/src/test/testData/parser/FSharpScriptDummyParserTests/empty.txt
+++ b/rider-fsharp/parserTest/src/test/testData/parser/FSharpScriptDummyParserTests/empty.txt
@@ -1,2 +1,3 @@
 FSharpFile
-  <empty list>
+  PsiElement(DUMMY_CONTAINER)
+    <empty list>

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/FSharpDummyParser.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/FSharpDummyParser.kt
@@ -3,6 +3,7 @@ package com.jetbrains.rider.ideaInterop.fileTypes.fsharp
 import com.intellij.lang.ASTNode
 import com.intellij.lang.PsiBuilder
 import com.intellij.lang.PsiParser
+import com.intellij.lang.impl.PsiBuilderImpl
 import com.intellij.psi.tree.IElementType
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer.FSharpTokenType
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.psi.impl.FSharpElementTypes
@@ -17,12 +18,28 @@ class FSharpDummyParser : PsiParser {
     builder.setWhitespaceSkippedCallback { elementType, _, end ->
       if (elementType == FSharpTokenType.NEW_LINE) currentLineStart = end
     }
-    builder.parseFile(root)
+    if (root == FSharpTokenType.DUMMY_CONTAINER) {
+      builder.parseDummyContainer()
+    } else if (root == FSharpElementTypes.FILE) {
+      builder.parseFile()
+    }
     return builder.treeBuilt
   }
 
-  private fun PsiBuilder.parseFile(fileElementType: IElementType) {
-    parseEvenEmpty(fileElementType) {
+  private fun PsiBuilder.parseFile() {
+    parseEvenEmpty(FSharpElementTypes.FILE) {
+      val marker = mark()
+      val lexemeCount =
+        if (this is PsiBuilderImpl) lexemeCount
+        else Int.MAX_VALUE - rawTokenIndex()
+
+      rawAdvanceLexer(lexemeCount)
+      marker.collapse(FSharpTokenType.DUMMY_CONTAINER)
+    }
+  }
+
+  private fun PsiBuilder.parseDummyContainer() {
+    parseEvenEmpty(FSharpTokenType.DUMMY_CONTAINER) {
       whileMakingProgress {
         if (!parseDummyExpression()) advanceLexerWithNewLineCounting()
         true

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpTokenType.java
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpTokenType.java
@@ -1,10 +1,31 @@
 package com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer;
 
+import com.intellij.lang.ASTNode;
+import com.intellij.lang.Language;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.impl.source.tree.LazyParseablePsiElement;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.tree.IReparseableElementType;
 import com.intellij.psi.tree.TokenSet;
+import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpLanguage;
 import org.jetbrains.annotations.NotNull;
 
 public interface FSharpTokenType {
+
+  IElementType DUMMY_CONTAINER = new IReparseableElementType("DUMMY_CONTAINER", FSharpLanguage.INSTANCE) {
+    @Override
+    public boolean isReparseable(@NotNull ASTNode currentNode,
+                                 @NotNull CharSequence newText,
+                                 @NotNull Language fileLanguage,
+                                 @NotNull Project project) {
+      return true;
+    }
+
+    @Override
+    public ASTNode createNode(CharSequence text) {
+      return new LazyParseablePsiElement(this, text);
+    }
+  };
 
   IElementType BIGNUM = createToken("BIGNUM");
   IElementType BLOCK_COMMENT = createToken("BLOCK_COMMENT");


### PR DESCRIPTION
If all the contents of a file are combined into a single `lazy parseable`, then
- only one event is sent during reparsing
- reparsing is reduced to a single `lazy parseable`, and its contents are replaced entirely.