### PR TITLE
Code structure/Patterns: fix NRE

### DIFF
--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Features/src/CodeStructure/FSharpCodeStructure.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Features/src/CodeStructure/FSharpCodeStructure.fs
@@ -8,6 +8,7 @@ open JetBrains.Application.BuildScript.Application.Zones
 open JetBrains.Application.Parts
 open JetBrains.Application.UI.Controls.JetPopupMenu
 open JetBrains.Application.UI.Controls.TreeView
+open JetBrains.DocumentModel
 open JetBrains.ProjectModel
 open JetBrains.RdBackend.Common.Env
 open JetBrains.ReSharper.Feature.Services.CodeStructure
@@ -175,11 +176,13 @@ type FSharpDeclarationCodeStructureElement(declaration: IDeclaration, parent, pa
 type FSharpPatternDeclarationCodeStructureElement(pat: IReferencePat, parent, parentBlock: ICodeStructureBlockStart) =
     inherit FSharpDeclarationCodeStructureElement(pat, parent, parentBlock)
 
-    let patternPointer = pat.GetPsiServices().Pointers.CreateTreeElementPointer(pat)
-
     override this.GetTextRange() =
-        match patternPointer.GetTreeNode().Binding with
-        | null -> base.GetTextRange()
+        match this.TreeNode.As<IReferencePat>() with
+        | null -> DocumentRange.InvalidRange
+        | pat ->
+
+        match pat.Binding with
+        | null -> pat.GetDocumentRange()
         | binding -> binding.GetDocumentRange()
 
 


### PR DESCRIPTION
Fix for 

```C#
com.jetbrains.rd.platform.diagnostics.BackendException: Object reference not set to an instance of an object.
--- EXCEPTION #1/3 [NullReferenceException]
Message = “Object reference not set to an instance of an object.”
StackTraceString = “
  at JetBrains.ReSharper.Plugins.FSharp.Psi.Features.CodeStructure.FSharpPatternDeclarationCodeStructureElement.GetTextRange() in GetTextRange.il:line IL_0000 mvid A583
     at JetBrains.Rider.Backend.Features.CodeStructure.BasicTreeBuilder.ConvertNode(TreeModelNode node, Int32 id, IDeclaredElement declaredElement, IDeclaration declaration, CodeStructureElement codeStructureElement) in ConvertNode.il:line IL_0031 mvid 6CDE
     at JetBrains.Rider.Backend.Features.CodeStructure.BasicTreeBuilder.ProcessNode(TreeModelNode root) in ProcessNode.il:line IL_003C mvid 6CDE or ProcessNode.il:line IL_00F8 mvid 6CDE
     at JetBrains.Rider.Backend.Features.CodeStructure.BasicTreeBuilder.ProcessNodeCollection(IBindableView`1 view, TreeModelNode parentNode) in ProcessNodeCollection.il:line IL_00DE mvid 6CDE
     at JetBrains.Rider.Backend.Features.CodeStructure.BasicTreeBuilder.ProcessNode(TreeModelNode root) in ProcessNode.il:line IL_003C mvid 6CDE or ProcessNode.il:line IL_00F8 mvid 6CDE
     at JetBrains.Rider.Backend.Features.CodeStructure.BasicTreeBuilder.ProcessNodeCollection(IBindableView`1 view, TreeModelNode parentNode) in ProcessNodeCollection.il:line IL_00DE mvid 6CDE
     at JetBrains.Rider.Backend.Features.CodeStructure.BasicTreeBuilder.Build() in Build.il:line IL_0041 mvid 6CDE
```