### PR TITLE
Import type: add a popup action

### DIFF
--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/QuickFixes/FSharpImportTypeFix.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/QuickFixes/FSharpImportTypeFix.fs
@@ -25,6 +25,16 @@ type FSharpImportTypeFix(reference) =
     override this.DoAdditionalOrdering(candidates) =
         FSharpImportTypeFix.doAdditionalSorting candidates
 
+type FSharpPopupImportTypeFix(reference) =
+    inherit ImportTypeQuickPopupFix(reference)
+
+    override this.GetSymbolScope(context) =
+        let symbolCache = context.GetPsiServices().Symbols
+        symbolCache.GetAlternativeNamesSymbolScope(context.GetPsiModule(), true)
+
+    override this.DoAdditionalOrdering(candidates) =
+        FSharpImportTypeFix.doAdditionalSorting candidates
+
 
 type FSharpReferenceModuleAndTypeFix(reference) =
     inherit ReferenceModuleAndTypeFix(reference)

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Services/src/Daemon/Highlightings/FcsErrors.xml
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Services/src/Daemon/Highlightings/FcsErrors.xml
@@ -158,6 +158,7 @@
     <Behavour attributeID="UNRESOLVED_ERROR" overlapResolvePolicy="NONE"/>
     <QuickFix>ToRecursiveFunctionFix</QuickFix>
     <QuickFix arguments="h.Reference">FSharpImportTypeFix</QuickFix>
+    <QuickFix arguments="h.Reference">FSharpPopupImportTypeFix</QuickFix>
     <QuickFix arguments="h.Reference">FSharpReferenceModuleAndTypeFix</QuickFix>
     <QuickFix arguments="h.Reference">FSharpImportExtensionMemberFix</QuickFix>
     <QuickFix arguments="h.Reference">FSharpImportModuleMemberFix</QuickFix>

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Features/Daemon/Highlightings/IdentifierHighlighting.cs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Features/Daemon/Highlightings/IdentifierHighlighting.cs
@@ -1,14 +1,16 @@
-﻿using JetBrains.Annotations;
-using JetBrains.Application.Parts;
+﻿using JetBrains.Application.Parts;
 using JetBrains.DocumentModel;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Daemon;
 using JetBrains.ReSharper.Daemon.Tooltips;
 using JetBrains.ReSharper.Feature.Services.Daemon;
+using JetBrains.ReSharper.Feature.Services.Daemon.Attributes;
 using JetBrains.ReSharper.Feature.Services.Descriptions;
 using JetBrains.ReSharper.Feature.Services.UI;
 using JetBrains.ReSharper.Psi;
+using JetBrains.UI.RichText;
+using static JetBrains.ReSharper.Psi.DeclaredElementPresentationPartKind;
 
 namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.Highlightings
 {
@@ -39,10 +41,28 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.Highlightings
   {
     public FSharpIdentifierTooltipProvider(Lifetime lifetime, ISolution solution,
       IDeclaredElementDescriptionPresenter presenter, DeclaredElementPresenterTextStylesService textStylesService,
-      IIdentifierTooltipSuppressor identifierTooltipSuppressor,
-      [CanBeNull] DeclaredElementPresenterTextStyles textStyles = null)
-      : base(lifetime, solution, presenter, textStylesService, identifierTooltipSuppressor, textStyles)
+      IIdentifierTooltipSuppressor identifierTooltipSuppressor)
+      : base(lifetime, solution, presenter, textStylesService, identifierTooltipSuppressor, Styles)
     {
     }
+
+    private static DeclaredElementPresenterTextStyles Styles { get; } = new DeclaredElementPresenterTextStyles
+    {
+      [Keyword] = new TextStyle(FSharpHighlightingAttributeIdsModule.Keyword),
+      [Namespace] = new TextStyle(FSharpHighlightingAttributeIdsModule.Namespace),
+      [Type] = new TextStyle(FSharpHighlightingAttributeIdsModule.Class),
+      [TypeUnresolved] = new TextStyle(AnalysisHighlightingAttributeIds.UNRESOLVED_ERROR),
+      [Method] = new TextStyle(FSharpHighlightingAttributeIdsModule.Method),
+      [SignOperator] = new TextStyle(FSharpHighlightingAttributeIdsModule.Operator),
+      [LocalVariable] = new TextStyle(FSharpHighlightingAttributeIdsModule.Value),
+      [LocalFunction] = new TextStyle(FSharpHighlightingAttributeIdsModule.Function),
+      [Field] = new TextStyle(FSharpHighlightingAttributeIdsModule.Field),
+      [Property] = new TextStyle(FSharpHighlightingAttributeIdsModule.Property),
+      [Event] = new TextStyle(FSharpHighlightingAttributeIdsModule.Event),
+      [Constructor] = new TextStyle(FSharpHighlightingAttributeIdsModule.Class),
+      [String] = new TextStyle(FSharpHighlightingAttributeIdsModule.String),
+      [Number] = new TextStyle(FSharpHighlightingAttributeIdsModule.Number),
+      [Comment] = new TextStyle(FSharpHighlightingAttributeIdsModule.LineComment),
+    }.Freeze();
   }
 }

--- a/ReSharper.FSharp/test/data/features/quickFixes/importType/popup/Type 01.fs
+++ b/ReSharper.FSharp/test/data/features/quickFixes/importType/popup/Type 01.fs
@@ -1,0 +1,1 @@
+let s: StreamReader{caret} = ""

--- a/ReSharper.FSharp/test/data/features/quickFixes/importType/popup/Type 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/quickFixes/importType/popup/Type 01.fs.gold
@@ -1,0 +1,3 @@
+﻿open System.IO
+
+let s: StreamReader{caret} = ""

--- a/ReSharper.FSharp/test/data/features/quickFixes/importType/popup/Type 02 - Multiple.fs
+++ b/ReSharper.FSharp/test/data/features/quickFixes/importType/popup/Type 02 - Multiple.fs
@@ -1,0 +1,2 @@
+let x: Action<int> = null
+let y: StreamReader{caret} = null

--- a/ReSharper.FSharp/test/data/features/quickFixes/importType/popup/Type 02 - Multiple.fs.gold
+++ b/ReSharper.FSharp/test/data/features/quickFixes/importType/popup/Type 02 - Multiple.fs.gold
@@ -1,0 +1,5 @@
+﻿open System
+open System.IO
+
+let x: Action<int> = null
+let y: StreamReader{caret} = null

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/QuickFixes/ImportTypeTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/QuickFixes/ImportTypeTest.fs
@@ -1,5 +1,10 @@
 namespace JetBrains.ReSharper.Plugins.FSharp.Tests.Intentions.QuickFixes.Import
 
+open System.Linq
+open JetBrains.Diagnostics
+open JetBrains.DocumentModel
+open JetBrains.ReSharper.Feature.Services.Intentions.Scoped
+open JetBrains.ReSharper.Feature.Services.QuickFixes.Scoped.Popups
 open JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.QuickFixes
 open JetBrains.ReSharper.Plugins.FSharp.Settings
 open JetBrains.ReSharper.Plugins.FSharp.Tests
@@ -67,6 +72,23 @@ type ImportTypeTest() =
     [<Test>] member x.``Accessibility 07``() = x.DoNamedTest()
     [<Test>] member x.``Accessibility 08``() = x.DoNamedTestWithTwoFiles()
     [<Test>] member x.``Accessibility 09``() = x.DoNamedTestWithTwoFiles()
+
+[<FSharpTest>]
+type ImportTypePopupTest() =
+    inherit FSharpQuickFixTestBase<FSharpPopupImportTypeFix>()
+
+    override x.RelativeTestDataPath = "features/quickFixes/importType/popup"
+
+    override x.ExecuteBulbAction(textControl, actionOwner, _, _) =
+        let scopedPopupAction = actionOwner.QuickFix.As<IScopedPopupAction>()
+        let intentionPopup = 
+          ScopedIntentionsManager.TryGetScopedPopupAction(scopedPopupAction, x.Solution, textControl.Document.GetDocumentRange()).NotNull();
+
+        let singleAction = intentionPopup.Actions.Single().NotNull()
+        singleAction.Execute(x.Solution, textControl)
+
+    [<Test>] member x.``Type 01``() = x.DoNamedTest()
+    [<Test>] member x.``Type 02 - Multiple``() = x.DoNamedTest()
 
 
 [<FSharpTest>]

--- a/rider-fsharp/src/main/resources/META-INF/plugin.xml
+++ b/rider-fsharp/src/main/resources/META-INF/plugin.xml
@@ -29,6 +29,7 @@
 
     <backend.actions.support language="F#" implementationClass="com.jetbrains.rider.plugins.fsharp.actions.FSharpActionSupportPolicy" />
     <backend.autoPopup.support language="F#" implementationClass="com.jetbrains.rider.completion.BackendAndGenericRider" />
+    <backend.auto.import.support language="F#" implementationClass="com.jetbrains.rider.intentions.RiderAutoImportSupportPolicy" />
     <backend.markup.adapterFactory language="F#" implementationClass="com.jetbrains.rdclient.daemon.FrontendMarkupAdapterFactory" />
     <backend.typedHandler language="F#" implementationClass="com.jetbrains.rider.plugins.fsharp.editorActions.FSharpTypedHandler" />
     <enterHandlerDelegate implementation="com.jetbrains.rider.plugins.fsharp.editorActions.FSharpEnterHandlerDelegate"


### PR DESCRIPTION
Currently, this only works for importing types, as importing extensions and module members requires additional infrastructure work to allow multiple imports.